### PR TITLE
Add one-click email unsubscribe (CAN-SPAM)

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS `#__livingword_users` (
   `plan_id` int UNSIGNED NOT NULL DEFAULT 0 COMMENT 'FK to plans.id',
   `bible_version` varchar(20) NOT NULL DEFAULT '' COMMENT 'Translation code (e.g. kjv)',
   `email` tinyint NOT NULL DEFAULT 0 COMMENT 'Receive daily reading email (0/1)',
+  `unsubscribe_token` varchar(64) DEFAULT NULL COMMENT 'One-click email unsubscribe token',
   `plan_view` tinyint NOT NULL DEFAULT 0 COMMENT '0=default, 1=list, 2=calendar',
   `start_date` date DEFAULT NULL COMMENT 'Reading plan start date',
   `date_offset` int NOT NULL DEFAULT 0 COMMENT 'Day offset adjustment',

--- a/admin/sql/updates/mysql/5.2.0.sql
+++ b/admin/sql/updates/mysql/5.2.0.sql
@@ -1,0 +1,3 @@
+-- LivingWord 5.2.0 — Add unsubscribe token for CAN-SPAM compliance
+ALTER TABLE `#__livingword_users` ADD COLUMN IF NOT EXISTS
+  `unsubscribe_token` varchar(64) DEFAULT NULL COMMENT 'One-click email unsubscribe token' AFTER `email`;

--- a/admin/src/Table/CwmuserTable.php
+++ b/admin/src/Table/CwmuserTable.php
@@ -39,6 +39,9 @@ class CwmuserTable extends Table
     /** @var int|null Email subscription flag (0/1) @since 5.0.0 */
     public ?int $email = 0;
 
+    /** @var string|null One-click unsubscribe token @since 5.2.0 */
+    public ?string $unsubscribe_token = null;
+
     /** @var int|null Plan view preference (0=default, 1=list, 2=calendar) @since 5.2.0 */
     public ?int $plan_view = 0;
 

--- a/plg_task_livingword/src/Extension/Livingword.php
+++ b/plg_task_livingword/src/Extension/Livingword.php
@@ -15,6 +15,7 @@ namespace CWM\Plugin\Task\Livingword\Extension;
 
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmscriptureHelper;
+use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -110,9 +111,17 @@ class Livingword extends CMSPlugin implements SubscriberInterface
                 continue;
             }
 
+            // Ensure unsubscribe token exists
+            $token = CwmuserHelper::ensureUnsubscribeToken($db, (int) $sub->user_id);
+            $unsubscribeUrl = CwmuserHelper::getUnsubscribeUrl($token);
+
             $body = '<p>Today\'s reading (Day ' . $currentDay . '):</p>'
                   . CwmscriptureHelper::buildEmailContent($reading->reading, $version)
-                  . '<p>From ' . htmlspecialchars($siteName, ENT_QUOTES, 'UTF-8') . '</p>';
+                  . '<p>From ' . htmlspecialchars($siteName, ENT_QUOTES, 'UTF-8') . '</p>'
+                  . '<hr style="margin-top:20px;border:none;border-top:1px solid #ccc;">'
+                  . '<p style="font-size:0.85em;color:#666;">'
+                  . '<a href="' . htmlspecialchars($unsubscribeUrl, ENT_QUOTES, 'UTF-8') . '">'
+                  . 'Unsubscribe from daily reading emails</a></p>';
 
             try {
                 $mailer = $this->getApplication()->getContainer()->get(MailerFactoryInterface::class)->createMailer();
@@ -120,6 +129,11 @@ class Livingword extends CMSPlugin implements SubscriberInterface
                 $mailer->setSubject($siteName . ' - Daily Bible Reading');
                 $mailer->setBody($body);
                 $mailer->isHtml(true);
+
+                // RFC 8058: List-Unsubscribe header for one-click in email clients
+                $mailer->addCustomHeader('List-Unsubscribe', '<' . $unsubscribeUrl . '>');
+                $mailer->addCustomHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+
                 $mailer->send();
                 $sent++;
             } catch (\Exception $e) {

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -21,6 +21,11 @@ COM_LIVINGWORD_TOOLS_COMMENTARY="Bible Commentary"
 COM_LIVINGWORD_TOOLS_COMMENTARY_DESC="Read commentary and study notes."
 COM_LIVINGWORD_TOOLS_OPEN="Open"
 
+; Unsubscribe
+COM_LIVINGWORD_UNSUBSCRIBE_SUCCESS="You have been successfully unsubscribed from daily reading emails."
+COM_LIVINGWORD_UNSUBSCRIBE_INVALID="This unsubscribe link is invalid or has already been used."
+COM_LIVINGWORD_UNSUBSCRIBE_RESUBSCRIBE="Changed your mind? Log in and re-enable email notifications in your preferences."
+
 ; Audio player
 COM_LIVINGWORD_AUDIO_PLAY="Play Audio Bible"
 COM_LIVINGWORD_AUDIO_PAUSE="Pause"

--- a/site/src/Controller/CwmunsubscribeController.php
+++ b/site/src/Controller/CwmunsubscribeController.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Livingword\Site\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Controller\BaseController;
+
+/**
+ * Public unsubscribe controller — no login required.
+ *
+ * Handles one-click email unsubscribe via token from email footer links.
+ *
+ * @since  5.2.0
+ */
+class CwmunsubscribeController extends BaseController
+{
+    /**
+     * Unsubscribe a user from daily reading emails using their token.
+     *
+     * URL: index.php?option=com_livingword&task=cwmunsubscribe.unsubscribe&token=XXX
+     *
+     * @return  void
+     *
+     * @since   5.2.0
+     */
+    public function unsubscribe(): void
+    {
+        $token = $this->input->getString('token', '');
+        $db    = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+
+        $success = CwmuserHelper::unsubscribeByToken($db, $token);
+
+        $app = $this->app;
+        $app->setUserState('com_livingword.unsubscribe.success', $success);
+
+        $this->setRedirect(
+            \Joomla\CMS\Router\Route::_('index.php?option=com_livingword&view=cwmunsubscribe', false)
+        );
+    }
+}

--- a/site/src/Helper/CwmuserHelper.php
+++ b/site/src/Helper/CwmuserHelper.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Livingword\Site\Helper;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 
 /**
@@ -96,6 +97,11 @@ class CwmuserHelper
         $db->setQuery($query);
         $existingId = $db->loadResult();
 
+        // Auto-generate unsubscribe token for new records
+        if (empty($data->unsubscribe_token ?? null)) {
+            $data->unsubscribe_token = self::generateUnsubscribeToken();
+        }
+
         if ($existingId) {
             $data->id = (int) $existingId;
             $db->updateObject('#__livingword_users', $data, 'id');
@@ -124,6 +130,97 @@ class CwmuserHelper
             : Factory::getApplication()->getIdentity();
 
         return $user->authorise($action, 'com_livingword');
+    }
+
+    /**
+     * Generate a random unsubscribe token.
+     *
+     * @return  string  64-character hex token
+     *
+     * @since   5.2.0
+     */
+    public static function generateUnsubscribeToken(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+
+    /**
+     * Build the full unsubscribe URL for a given token.
+     *
+     * @param   string  $token  The unsubscribe token
+     *
+     * @return  string  Absolute URL
+     *
+     * @since   5.2.0
+     */
+    public static function getUnsubscribeUrl(string $token): string
+    {
+        return Uri::root() . 'index.php?option=com_livingword&task=cwmunsubscribe.unsubscribe&token=' . urlencode($token);
+    }
+
+    /**
+     * Unsubscribe a user by their token. No login required.
+     *
+     * @param   DatabaseInterface  $db     Database instance
+     * @param   string             $token  The unsubscribe token
+     *
+     * @return  bool  True if a matching user was found and unsubscribed
+     *
+     * @since   5.2.0
+     */
+    public static function unsubscribeByToken(DatabaseInterface $db, string $token): bool
+    {
+        if (empty($token) || \strlen($token) !== 64) {
+            return false;
+        }
+
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__livingword_users'))
+            ->set($db->quoteName('email') . ' = 0')
+            ->where($db->quoteName('unsubscribe_token') . ' = ' . $db->quote($token))
+            ->where($db->quoteName('email') . ' = 1');
+
+        $db->setQuery($query);
+        $db->execute();
+
+        return $db->getAffectedRows() > 0;
+    }
+
+    /**
+     * Ensure a user has an unsubscribe token, generating one if missing.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     *
+     * @return  string  The unsubscribe token
+     *
+     * @since   5.2.0
+     */
+    public static function ensureUnsubscribeToken(DatabaseInterface $db, int $userId): string
+    {
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('unsubscribe_token'))
+            ->from($db->quoteName('#__livingword_users'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId);
+
+        $db->setQuery($query);
+        $token = $db->loadResult();
+
+        if (!empty($token)) {
+            return $token;
+        }
+
+        $token = self::generateUnsubscribeToken();
+
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__livingword_users'))
+            ->set($db->quoteName('unsubscribe_token') . ' = ' . $db->quote($token))
+            ->where($db->quoteName('user_id') . ' = ' . $userId);
+
+        $db->setQuery($query);
+        $db->execute();
+
+        return $token;
     }
 
     /**

--- a/site/src/View/Cwmunsubscribe/HtmlView.php
+++ b/site/src/View/Cwmunsubscribe/HtmlView.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Livingword\Site\View\Cwmunsubscribe;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+
+/**
+ * Unsubscribe confirmation view.
+ *
+ * @since  5.2.0
+ */
+class HtmlView extends BaseHtmlView
+{
+    /** @var bool @since 5.2.0 */
+    protected bool $success = false;
+
+    /**
+     * @param   string  $tpl  Template name.
+     *
+     * @return  void
+     *
+     * @throws  \Exception
+     * @since   5.2.0
+     */
+    #[\Override]
+    public function display($tpl = null): void
+    {
+        $app = Factory::getApplication();
+        $this->success = (bool) $app->getUserState('com_livingword.unsubscribe.success', false);
+
+        // Clear the state so refreshing doesn't re-show success
+        $app->setUserState('com_livingword.unsubscribe.success', null);
+
+        parent::display($tpl);
+    }
+}

--- a/site/tmpl/cwmunsubscribe/default.php
+++ b/site/tmpl/cwmunsubscribe/default.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+/** @var \CWM\Component\Livingword\Site\View\Cwmunsubscribe\HtmlView $this */
+?>
+<div class="com-livingword-unsubscribe">
+    <?php if ($this->success) : ?>
+        <div class="alert alert-success">
+            <h4><?php echo Text::_('COM_LIVINGWORD_UNSUBSCRIBE_SUCCESS'); ?></h4>
+        </div>
+        <p><?php echo Text::_('COM_LIVINGWORD_UNSUBSCRIBE_RESUBSCRIBE'); ?></p>
+    <?php else : ?>
+        <div class="alert alert-warning">
+            <h4><?php echo Text::_('COM_LIVINGWORD_UNSUBSCRIBE_INVALID'); ?></h4>
+        </div>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
## Summary
Adds CAN-SPAM compliant one-click unsubscribe to daily reading emails. Closes #8.

## What changed
- `unsubscribe_token` varchar(64) column on `#__livingword_users`
- Token auto-generated on user record creation and on first email send
- Public endpoint `cwmunsubscribe.unsubscribe?token=XXX` — no login required
- Every email includes footer unsubscribe link
- `List-Unsubscribe` + `List-Unsubscribe-Post` headers (RFC 8058) for one-click in Gmail/Outlook/Apple Mail
- Confirmation view with re-subscribe guidance

## Type of change
- [x] New feature
- [x] Chore / tooling / infrastructure

## Database changes
- [x] New column: `unsubscribe_token` on `#__livingword_users`
- [x] Migration: `admin/sql/updates/mysql/5.2.0.sql`

## Checklist
- [x] Language strings added
- [x] SQL update script added
- [x] `composer lint:syntax` passes (60 files, 0 errors)

Generated with [Claude Code](https://claude.com/claude-code)