### PR TITLE
Add per-day reading completion tracking

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -49,6 +49,17 @@ CREATE TABLE IF NOT EXISTS `#__livingword_users` (
   KEY `idx_plan_id` (`plan_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS `#__livingword_progress` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL COMMENT 'FK to #__users.id',
+  `plan_id` int UNSIGNED NOT NULL COMMENT 'FK to plans.id',
+  `day` int UNSIGNED NOT NULL COMMENT '1-based day number',
+  `completed_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_user_plan_day` (`user_id`, `plan_id`, `day`),
+  KEY `idx_user_plan` (`user_id`, `plan_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS `#__livingword_links` (
   `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` varchar(200) NOT NULL DEFAULT '',

--- a/admin/sql/updates/mysql/5.3.0.sql
+++ b/admin/sql/updates/mysql/5.3.0.sql
@@ -1,0 +1,11 @@
+-- LivingWord 5.3.0 — Reading completion tracking
+CREATE TABLE IF NOT EXISTS `#__livingword_progress` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL COMMENT 'FK to #__users.id',
+  `plan_id` int UNSIGNED NOT NULL COMMENT 'FK to plans.id',
+  `day` int UNSIGNED NOT NULL COMMENT '1-based day number',
+  `completed_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_user_plan_day` (`user_id`, `plan_id`, `day`),
+  KEY `idx_user_plan` (`user_id`, `plan_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/admin/src/Controller/CwmutilitiesController.php
+++ b/admin/src/Controller/CwmutilitiesController.php
@@ -38,6 +38,7 @@ class CwmutilitiesController extends BaseController
         '#__livingword_links',
         '#__livingword_plans',
         '#__livingword_plans_details',
+        '#__livingword_progress',
     ];
 
     /**

--- a/media/com_livingword/js/livingword-progress.js
+++ b/media/com_livingword/js/livingword-progress.js
@@ -1,0 +1,83 @@
+/**
+ * LivingWord — Reading completion toggle
+ *
+ * Handles "Mark as Read" buttons via AJAX. Requires a CSRF token
+ * passed via Joomla's script options (csrf.token).
+ *
+ * @since 5.3.0
+ */
+((document) => {
+  'use strict';
+
+  const init = () => {
+    document.querySelectorAll('[data-livingword-progress]').forEach(setupToggle);
+  };
+
+  const setupToggle = (container) => {
+    const btn = container.querySelector('.livingword-mark-read-btn');
+    if (!btn) return;
+
+    let busy = false;
+
+    btn.addEventListener('click', async (e) => {
+      e.preventDefault();
+      if (busy) return;
+      busy = true;
+
+      const planId = container.dataset.planId;
+      const day = container.dataset.day;
+      const tokenName = Joomla.getOptions('csrf.token') || '';
+
+      const url = container.dataset.progressUrl
+        + '&plan_id=' + encodeURIComponent(planId)
+        + '&day=' + encodeURIComponent(day)
+        + '&' + encodeURIComponent(tokenName) + '=1';
+
+      btn.disabled = true;
+
+      try {
+        const response = await fetch(url, { method: 'GET', credentials: 'same-origin' });
+        if (!response.ok) throw new Error('HTTP ' + response.status);
+
+        const json = await response.json();
+
+        if (json.success && json.data) {
+          const completed = json.data.completed;
+          container.dataset.completed = completed ? '1' : '0';
+
+          // Update button text and icon
+          const icon = btn.querySelector('.icon-checkmark, .icon-checkbox-unchecked, .icon-check, .icon-unchecked');
+          if (completed) {
+            btn.classList.add('btn-success');
+            btn.classList.remove('btn-outline-secondary');
+            if (icon) icon.className = 'icon-checkmark';
+            btn.setAttribute('aria-label', btn.dataset.labelRead || 'Mark as Unread');
+          } else {
+            btn.classList.remove('btn-success');
+            btn.classList.add('btn-outline-secondary');
+            if (icon) icon.className = 'icon-checkbox-unchecked';
+            btn.setAttribute('aria-label', btn.dataset.labelUnread || 'Mark as Read');
+          }
+
+          // Update any checkmark indicators on the page for this day
+          document.querySelectorAll('[data-progress-day="' + day + '"]').forEach(el => {
+            el.classList.toggle('livingword-completed', completed);
+          });
+        } else {
+          console.error('LivingWord progress error:', json.message || 'Unknown error');
+        }
+      } catch (err) {
+        console.error('LivingWord progress fetch error:', err);
+      } finally {
+        btn.disabled = false;
+        busy = false;
+      }
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(document);

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -21,6 +21,11 @@ COM_LIVINGWORD_TOOLS_COMMENTARY="Bible Commentary"
 COM_LIVINGWORD_TOOLS_COMMENTARY_DESC="Read commentary and study notes."
 COM_LIVINGWORD_TOOLS_OPEN="Open"
 
+; Reading completion
+COM_LIVINGWORD_MARK_READ="Mark as Read"
+COM_LIVINGWORD_MARK_UNREAD="Mark as Unread"
+COM_LIVINGWORD_COMPLETED="Completed"
+
 ; Unsubscribe
 COM_LIVINGWORD_UNSUBSCRIBE_SUCCESS="You have been successfully unsubscribed from daily reading emails."
 COM_LIVINGWORD_UNSUBSCRIBE_INVALID="This unsubscribe link is invalid or has already been used."

--- a/site/src/Controller/CwmprogressController.php
+++ b/site/src/Controller/CwmprogressController.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Livingword\Site\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Response\JsonResponse;
+use Joomla\CMS\Session\Session;
+
+/**
+ * AJAX controller for reading completion tracking.
+ *
+ * @since  5.3.0
+ */
+class CwmprogressController extends BaseController
+{
+    /**
+     * Toggle completion for a reading day. Returns JSON.
+     *
+     * @return  void
+     *
+     * @since   5.3.0
+     */
+    public function toggle(): void
+    {
+        $app = $this->app;
+        $app->setHeader('Content-Type', 'application/json; charset=utf-8');
+
+        if (!Session::checkToken('get')) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Invalid session token', true);
+            $app->close();
+        }
+
+        $userId = (int) $app->getIdentity()->id;
+
+        if ($userId === 0) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Login required', true);
+            $app->close();
+        }
+
+        $planId = $this->input->getInt('plan_id', 0);
+        $day    = $this->input->getInt('day', 0);
+
+        if ($planId <= 0 || $day <= 0) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Invalid plan or day', true);
+            $app->close();
+        }
+
+        $db        = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $completed = CwmprogressHelper::toggleComplete($db, $userId, $planId, $day);
+
+        $app->sendHeaders();
+        echo new JsonResponse([
+            'completed' => $completed,
+            'day'       => $day,
+            'plan_id'   => $planId,
+        ]);
+        $app->close();
+    }
+}

--- a/site/src/Helper/CwmprogressHelper.php
+++ b/site/src/Helper/CwmprogressHelper.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Livingword\Site\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Reading progress tracking helper.
+ *
+ * Manages per-day completion records in #__livingword_progress.
+ *
+ * @since  5.3.0
+ */
+class CwmprogressHelper
+{
+    /**
+     * Check if a specific day is completed for a user/plan.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     * @param   int                $planId  Plan ID
+     * @param   int                $day     Day number (1-based)
+     *
+     * @return  bool
+     *
+     * @since   5.3.0
+     */
+    public static function isCompleted(DatabaseInterface $db, int $userId, int $planId, int $day): bool
+    {
+        $query = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__livingword_progress'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->where($db->quoteName('day') . ' = ' . $day);
+
+        $db->setQuery($query);
+
+        return (int) $db->loadResult() > 0;
+    }
+
+    /**
+     * Mark a day as complete.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     * @param   int                $planId  Plan ID
+     * @param   int                $day     Day number (1-based)
+     *
+     * @return  void
+     *
+     * @since   5.3.0
+     */
+    public static function markComplete(DatabaseInterface $db, int $userId, int $planId, int $day): void
+    {
+        $record = (object) [
+            'user_id' => $userId,
+            'plan_id' => $planId,
+            'day'     => $day,
+        ];
+
+        try {
+            $db->insertObject('#__livingword_progress', $record);
+        } catch (\RuntimeException) {
+            // Already exists (unique constraint) — ignore
+        }
+    }
+
+    /**
+     * Mark a day as incomplete (remove completion record).
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     * @param   int                $planId  Plan ID
+     * @param   int                $day     Day number (1-based)
+     *
+     * @return  void
+     *
+     * @since   5.3.0
+     */
+    public static function markIncomplete(DatabaseInterface $db, int $userId, int $planId, int $day): void
+    {
+        $query = $db->getQuery(true)
+            ->delete($db->quoteName('#__livingword_progress'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->where($db->quoteName('day') . ' = ' . $day);
+
+        $db->setQuery($query);
+        $db->execute();
+    }
+
+    /**
+     * Toggle completion for a day. Returns the new state.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     * @param   int                $planId  Plan ID
+     * @param   int                $day     Day number (1-based)
+     *
+     * @return  bool  True if now completed, false if now incomplete
+     *
+     * @since   5.3.0
+     */
+    public static function toggleComplete(DatabaseInterface $db, int $userId, int $planId, int $day): bool
+    {
+        if (self::isCompleted($db, $userId, $planId, $day)) {
+            self::markIncomplete($db, $userId, $planId, $day);
+
+            return false;
+        }
+
+        self::markComplete($db, $userId, $planId, $day);
+
+        return true;
+    }
+
+    /**
+     * Get all completed day numbers for a user/plan.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     * @param   int                $planId  Plan ID
+     *
+     * @return  array  Array of completed day numbers
+     *
+     * @since   5.3.0
+     */
+    public static function getCompletedDays(DatabaseInterface $db, int $userId, int $planId): array
+    {
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('day'))
+            ->from($db->quoteName('#__livingword_progress'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->order($db->quoteName('day') . ' ASC');
+
+        $db->setQuery($query);
+
+        return $db->loadColumn() ?: [];
+    }
+
+    /**
+     * Get the count of completed days for a user/plan.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     * @param   int                $planId  Plan ID
+     *
+     * @return  int
+     *
+     * @since   5.3.0
+     */
+    public static function getCompletedCount(DatabaseInterface $db, int $userId, int $planId): int
+    {
+        $query = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__livingword_progress'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId);
+
+        $db->setQuery($query);
+
+        return (int) $db->loadResult();
+    }
+}

--- a/site/src/Model/CwmhomeModel.php
+++ b/site/src/Model/CwmhomeModel.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Factory;
@@ -47,12 +48,17 @@ class CwmhomeModel extends BaseDatabaseModel
         $todayReading = CwmreadingHelper::getReadingForDay($db, $planId, $currentDay);
         $planInfo     = CwmreadingHelper::getPlanById($db, $planId);
 
+        $isCompleted = ($userId > 0)
+            ? CwmprogressHelper::isCompleted($db, $userId, $planId, $currentDay)
+            : false;
+
         return (object) [
             'userData'     => $userData,
             'todayReading' => $todayReading,
             'planInfo'     => $planInfo,
             'currentDay'   => $currentDay,
             'totalDays'    => $totalDays,
+            'isCompleted'  => $isCompleted,
         ];
     }
 }

--- a/site/src/Model/CwmplanviewModel.php
+++ b/site/src/Model/CwmplanviewModel.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Factory;
@@ -50,12 +51,17 @@ class CwmplanviewModel extends BaseDatabaseModel
             $totalDays ?: 365
         );
 
+        $completedDays = ($userId > 0)
+            ? CwmprogressHelper::getCompletedDays($db, $userId, $planId)
+            : [];
+
         return (object) [
-            'planInfo'   => $planInfo,
-            'readings'   => $readings,
-            'userData'   => $userData,
-            'currentDay' => $currentDay,
-            'totalDays'  => $totalDays,
+            'planInfo'      => $planInfo,
+            'readings'      => $readings,
+            'userData'      => $userData,
+            'currentDay'    => $currentDay,
+            'totalDays'     => $totalDays,
+            'completedDays' => $completedDays,
         ];
     }
 }

--- a/site/tmpl/cwmhome/default.php
+++ b/site/tmpl/cwmhome/default.php
@@ -24,6 +24,19 @@ $reading = $data->todayReading;
 $plan    = $data->planInfo;
 $user    = $data->userData;
 
+// Progress tracking
+$isLoggedIn  = (int) ($user->user_id ?? 0) > 0;
+$isCompleted = $data->isCompleted ?? false;
+$progressUrl = Route::_('index.php?option=com_livingword&task=cwmprogress.toggle&format=json', false);
+
+if ($isLoggedIn && $reading) {
+    /** @var \Joomla\CMS\Document\HtmlDocument $doc */
+    $doc = $this->getDocument();
+    $wa  = $doc->getWebAssetManager();
+    $wa->registerAndUseScript('com_livingword.progress', 'media/com_livingword/js/livingword-progress.js', [], ['defer' => true]);
+    $doc->addScriptOptions('csrf.token', Session::getFormToken());
+}
+
 // Audio availability check
 $showAudio = $plan && (int) ($plan->audio ?? 0) === 1 && CwmscriptureHelper::isAudioAvailable();
 
@@ -79,6 +92,23 @@ if ($showAudio && $reading) {
                 <?php endif; ?>
                 <?php if (!empty($reading->descrip)) : ?>
                     <p class="text-muted"><?php echo $this->escape($reading->descrip); ?></p>
+                <?php endif; ?>
+                <?php if ($isLoggedIn) : ?>
+                    <div class="livingword-progress-toggle mt-3"
+                         data-livingword-progress
+                         data-plan-id="<?php echo (int) ($plan->id ?? 0); ?>"
+                         data-day="<?php echo (int) $data->currentDay; ?>"
+                         data-completed="<?php echo $isCompleted ? '1' : '0'; ?>"
+                         data-progress-url="<?php echo $this->escape($progressUrl); ?>">
+                        <button type="button"
+                                class="btn <?php echo $isCompleted ? 'btn-success' : 'btn-outline-secondary'; ?> livingword-mark-read-btn"
+                                data-label-read="<?php echo Text::_('COM_LIVINGWORD_MARK_UNREAD'); ?>"
+                                data-label-unread="<?php echo Text::_('COM_LIVINGWORD_MARK_READ'); ?>"
+                                aria-label="<?php echo $isCompleted ? Text::_('COM_LIVINGWORD_MARK_UNREAD') : Text::_('COM_LIVINGWORD_MARK_READ'); ?>">
+                            <span class="<?php echo $isCompleted ? 'icon-checkmark' : 'icon-checkbox-unchecked'; ?>" aria-hidden="true"></span>
+                            <?php echo $isCompleted ? Text::_('COM_LIVINGWORD_COMPLETED') : Text::_('COM_LIVINGWORD_MARK_READ'); ?>
+                        </button>
+                    </div>
                 <?php endif; ?>
             </div>
         <?php else : ?>

--- a/site/tmpl/cwmplanview/calendar.php
+++ b/site/tmpl/cwmplanview/calendar.php
@@ -20,7 +20,8 @@ $data     = $this->planData;
 $readings = $data->readings;
 $plan     = $data->planInfo;
 $user     = $data->userData;
-$startDate = new \DateTime($user->start_date ?: date('Y-01-01'));
+$startDate     = new \DateTime($user->start_date ?: date('Y-01-01'));
+$completedDays = array_flip($data->completedDays ?? []);
 ?>
 <div class="com-livingword-planview-calendar">
     <?php echo $this->menu; ?>
@@ -62,10 +63,15 @@ $startDate = new \DateTime($user->start_date ?: date('Y-01-01'));
             <h3><?php echo $month['label']; ?></h3>
             <div class="row row-cols-7 g-1 mb-3">
                 <?php foreach ($month['readings'] as $entry) : ?>
+                    <?php $isDayCompleted = isset($completedDays[$entry['day']]); ?>
                     <div class="col">
-                        <div class="card<?php echo $entry['current'] ? ' border-primary' : ''; ?> h-100">
+                        <div class="card<?php echo $entry['current'] ? ' border-primary' : ($isDayCompleted ? ' border-success' : ''); ?> h-100" data-progress-day="<?php echo $entry['day']; ?>">
                             <div class="card-body p-1 small">
-                                <strong><?php echo $entry['date']; ?></strong><br>
+                                <strong><?php echo $entry['date']; ?></strong>
+                                <?php if ($isDayCompleted) : ?>
+                                    <span class="icon-checkmark text-success float-end" aria-hidden="true"></span>
+                                <?php endif; ?>
+                                <br>
                                 <?php
                                 echo CwmscriptureHelper::buildReadingLink($entry['reading']->reading, $user->bible_version);
                                 ?>

--- a/site/tmpl/cwmplanview/default.php
+++ b/site/tmpl/cwmplanview/default.php
@@ -16,10 +16,11 @@ use Joomla\CMS\Language\Text;
 
 /** @var \CWM\Component\Livingword\Site\View\Cwmplanview\HtmlView $this */
 
-$data     = $this->planData;
-$readings = $data->readings;
-$plan     = $data->planInfo;
-$user     = $data->userData;
+$data          = $this->planData;
+$readings      = $data->readings;
+$plan          = $data->planInfo;
+$user          = $data->userData;
+$completedDays = array_flip($data->completedDays ?? []);
 ?>
 <div class="com-livingword-planview">
     <?php echo $this->menu; ?>
@@ -34,14 +35,29 @@ $user     = $data->userData;
         <table class="table table-striped">
             <thead>
                 <tr>
+                    <th class="w-5 text-center"></th>
                     <th class="w-10"><?php echo Text::_('COM_LIVINGWORD_DAY'); ?></th>
                     <th><?php echo Text::_('COM_LIVINGWORD_READING'); ?></th>
                 </tr>
             </thead>
             <tbody>
                 <?php foreach ($readings as $i => $reading) : ?>
-                    <?php $dayNum = $i + 1; ?>
-                    <tr<?php echo $dayNum === $data->currentDay ? ' class="table-active fw-bold"' : ''; ?>>
+                    <?php
+                    $dayNum      = $i + 1;
+                    $isCompleted = isset($completedDays[$dayNum]);
+                    $rowClass    = '';
+                    if ($dayNum === $data->currentDay) {
+                        $rowClass = 'table-active fw-bold';
+                    } elseif ($isCompleted) {
+                        $rowClass = 'table-success';
+                    }
+                    ?>
+                    <tr<?php echo $rowClass ? ' class="' . $rowClass . '"' : ''; ?> data-progress-day="<?php echo $dayNum; ?>">
+                        <td class="text-center">
+                            <?php if ($isCompleted) : ?>
+                                <span class="icon-checkmark text-success" aria-label="<?php echo Text::_('COM_LIVINGWORD_COMPLETED'); ?>"></span>
+                            <?php endif; ?>
+                        </td>
                         <td><?php echo $dayNum; ?></td>
                         <td>
                             <?php echo CwmscriptureHelper::buildReadingLink($reading->reading, $user->bible_version); ?>


### PR DESCRIPTION
## Summary
Adds reading completion tracking — users can mark daily readings as complete. Closes #3.

## What changed
- New `#__livingword_progress` table (user_id, plan_id, day, completed_at)
- `CwmprogressHelper`: full CRUD for completion records
- `CwmprogressController`: AJAX toggle endpoint returning JSON
- Home view: "Mark as Read" button with async toggle (green when completed)
- Plan list view: checkmark column + green highlight for completed days
- Calendar view: green border + checkmark for completed days
- `livingword-progress.js`: handles click → fetch → DOM update cycle

## Foundation for
- #4 Progress indicator (% complete)
- #5 Reading streak tracking
- #7 Chapter-level completion

## Type of change
- [x] New feature

## Database changes
- [x] New table: `#__livingword_progress`
- [x] Migration: `admin/sql/updates/mysql/5.3.0.sql`

## Checklist
- [x] Language strings added (MARK_READ, MARK_UNREAD, COMPLETED)
- [x] SQL update script added
- [x] `composer lint:syntax` passes (62 files, 0 errors)
- [x] Verified on j6-dev

Generated with [Claude Code](https://claude.com/claude-code)