### PR TITLE
Add progress indicator (% complete + day count)

### DIFF
--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -26,6 +26,10 @@ COM_LIVINGWORD_MARK_READ="Mark as Read"
 COM_LIVINGWORD_MARK_UNREAD="Mark as Unread"
 COM_LIVINGWORD_COMPLETED="Completed"
 
+; Progress
+COM_LIVINGWORD_PROGRESS_PERCENT="%d%% Complete"
+COM_LIVINGWORD_PROGRESS_DAYS="%d of %d readings completed"
+
 ; Unsubscribe
 COM_LIVINGWORD_UNSUBSCRIBE_SUCCESS="You have been successfully unsubscribed from daily reading emails."
 COM_LIVINGWORD_UNSUBSCRIBE_INVALID="This unsubscribe link is invalid or has already been used."

--- a/site/src/Model/CwmhomeModel.php
+++ b/site/src/Model/CwmhomeModel.php
@@ -48,17 +48,25 @@ class CwmhomeModel extends BaseDatabaseModel
         $todayReading = CwmreadingHelper::getReadingForDay($db, $planId, $currentDay);
         $planInfo     = CwmreadingHelper::getPlanById($db, $planId);
 
-        $isCompleted = ($userId > 0)
-            ? CwmprogressHelper::isCompleted($db, $userId, $planId, $currentDay)
-            : false;
+        $isCompleted    = false;
+        $completedCount = 0;
+
+        if ($userId > 0) {
+            $isCompleted    = CwmprogressHelper::isCompleted($db, $userId, $planId, $currentDay);
+            $completedCount = CwmprogressHelper::getCompletedCount($db, $userId, $planId);
+        }
+
+        $progressPercent = ($totalDays > 0) ? round(($completedCount / $totalDays) * 100) : 0;
 
         return (object) [
-            'userData'     => $userData,
-            'todayReading' => $todayReading,
-            'planInfo'     => $planInfo,
-            'currentDay'   => $currentDay,
-            'totalDays'    => $totalDays,
-            'isCompleted'  => $isCompleted,
+            'userData'        => $userData,
+            'todayReading'    => $todayReading,
+            'planInfo'        => $planInfo,
+            'currentDay'      => $currentDay,
+            'totalDays'       => $totalDays,
+            'isCompleted'     => $isCompleted,
+            'completedCount'  => $completedCount,
+            'progressPercent' => $progressPercent,
         ];
     }
 }

--- a/site/src/Model/CwmplanviewModel.php
+++ b/site/src/Model/CwmplanviewModel.php
@@ -55,13 +55,18 @@ class CwmplanviewModel extends BaseDatabaseModel
             ? CwmprogressHelper::getCompletedDays($db, $userId, $planId)
             : [];
 
+        $completedCount  = \count($completedDays);
+        $progressPercent = ($totalDays > 0) ? round(($completedCount / $totalDays) * 100) : 0;
+
         return (object) [
-            'planInfo'      => $planInfo,
-            'readings'      => $readings,
-            'userData'      => $userData,
-            'currentDay'    => $currentDay,
-            'totalDays'     => $totalDays,
-            'completedDays' => $completedDays,
+            'planInfo'        => $planInfo,
+            'readings'        => $readings,
+            'userData'        => $userData,
+            'currentDay'      => $currentDay,
+            'totalDays'       => $totalDays,
+            'completedDays'   => $completedDays,
+            'completedCount'  => $completedCount,
+            'progressPercent' => $progressPercent,
         ];
     }
 }

--- a/site/tmpl/cwmhome/default.php
+++ b/site/tmpl/cwmhome/default.php
@@ -64,7 +64,22 @@ if ($showAudio && $reading) {
             <?php endif; ?>
         <?php endif; ?>
 
-        <h3><?php echo Text::sprintf('COM_LIVINGWORD_DAY_OF', $data->currentDay, $data->totalDays); ?></h3>
+        <div class="livingword-progress-info mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <h3 class="mb-0"><?php echo Text::sprintf('COM_LIVINGWORD_DAY_OF', $data->currentDay, $data->totalDays); ?></h3>
+                <?php if ($isLoggedIn && $data->totalDays > 0) : ?>
+                    <span class="badge bg-primary"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_PERCENT', $data->progressPercent); ?></span>
+                <?php endif; ?>
+            </div>
+            <?php if ($isLoggedIn && $data->totalDays > 0) : ?>
+                <div class="progress" style="height: 8px;" role="progressbar"
+                     aria-valuenow="<?php echo $data->progressPercent; ?>" aria-valuemin="0" aria-valuemax="100"
+                     aria-label="<?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_PERCENT', $data->progressPercent); ?>">
+                    <div class="progress-bar bg-success" style="width: <?php echo $data->progressPercent; ?>%"></div>
+                </div>
+                <small class="text-muted"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_DAYS', $data->completedCount, $data->totalDays); ?></small>
+            <?php endif; ?>
+        </div>
 
         <?php if ($reading) : ?>
             <div class="livingword-today-reading">

--- a/site/tmpl/cwmplanview/calendar.php
+++ b/site/tmpl/cwmplanview/calendar.php
@@ -30,6 +30,19 @@ $completedDays = array_flip($data->completedDays ?? []);
         <h2><?php echo $this->escape($plan->description); ?></h2>
     <?php endif; ?>
 
+    <?php if ($data->totalDays > 0 && ($data->completedCount ?? 0) > 0) : ?>
+        <div class="livingword-progress-info mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <span><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_DAYS', $data->completedCount, $data->totalDays); ?></span>
+                <span class="badge bg-primary"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_PERCENT', $data->progressPercent); ?></span>
+            </div>
+            <div class="progress" style="height: 8px;" role="progressbar"
+                 aria-valuenow="<?php echo $data->progressPercent; ?>" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-bar bg-success" style="width: <?php echo $data->progressPercent; ?>%"></div>
+            </div>
+        </div>
+    <?php endif; ?>
+
     <?php if (empty($readings)) : ?>
         <div class="alert alert-info"><?php echo Text::_('COM_LIVINGWORD_NO_READINGS'); ?></div>
     <?php else : ?>

--- a/site/tmpl/cwmplanview/default.php
+++ b/site/tmpl/cwmplanview/default.php
@@ -29,6 +29,19 @@ $completedDays = array_flip($data->completedDays ?? []);
         <h2><?php echo $this->escape($plan->description); ?></h2>
     <?php endif; ?>
 
+    <?php if ($data->totalDays > 0 && $data->completedCount > 0) : ?>
+        <div class="livingword-progress-info mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <span><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_DAYS', $data->completedCount, $data->totalDays); ?></span>
+                <span class="badge bg-primary"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_PERCENT', $data->progressPercent); ?></span>
+            </div>
+            <div class="progress" style="height: 8px;" role="progressbar"
+                 aria-valuenow="<?php echo $data->progressPercent; ?>" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-bar bg-success" style="width: <?php echo $data->progressPercent; ?>%"></div>
+            </div>
+        </div>
+    <?php endif; ?>
+
     <?php if (empty($readings)) : ?>
         <div class="alert alert-info"><?php echo Text::_('COM_LIVINGWORD_NO_READINGS'); ?></div>
     <?php else : ?>


### PR DESCRIPTION
## Summary
Shows reading progress as a percentage bar and day count on home and plan views. Closes #4.

## What changed
- Home view: progress bar with "X% Complete" badge and "X of Y readings completed"
- Plan list view: progress bar above readings table
- Calendar view: progress bar above calendar grid
- Models return `completedCount` and `progressPercent` from CwmprogressHelper
- Guest users see no progress (requires login + completion data from #3)
- Uses Bootstrap progress component with ARIA attributes

## Depends on
- #3 (completion tracking) — merged

Generated with [Claude Code](https://claude.com/claude-code)