### PR TITLE
Add accountability partner feature

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -45,6 +45,8 @@ CREATE TABLE IF NOT EXISTS `#__livingword_users` (
   `streak_current` int NOT NULL DEFAULT 0 COMMENT 'Current consecutive days read',
   `streak_best` int NOT NULL DEFAULT 0 COMMENT 'Best streak ever achieved',
   `streak_last_date` date DEFAULT NULL COMMENT 'Last date a reading was completed',
+  `accountability_partner_id` int DEFAULT NULL COMMENT 'FK to #__users.id — paired partner',
+  `share_progress` tinyint NOT NULL DEFAULT 0 COMMENT 'Share progress with partner (0/1)',
   `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/admin/sql/updates/mysql/5.6.0.sql
+++ b/admin/sql/updates/mysql/5.6.0.sql
@@ -1,0 +1,8 @@
+-- Add accountability partner columns (#10)
+ALTER TABLE `#__livingword_users`
+  ADD COLUMN `accountability_partner_id` int DEFAULT NULL
+  COMMENT 'FK to #__users.id — paired partner'
+  AFTER `streak_last_date`,
+  ADD COLUMN `share_progress` tinyint NOT NULL DEFAULT 0
+  COMMENT 'Share progress with partner (0/1)'
+  AFTER `accountability_partner_id`;

--- a/admin/src/Table/CwmuserTable.php
+++ b/admin/src/Table/CwmuserTable.php
@@ -60,6 +60,12 @@ class CwmuserTable extends Table
     /** @var string|null Last date a reading was completed @since 5.4.0 */
     public ?string $streak_last_date = null;
 
+    /** @var int|null FK to #__users.id — accountability partner @since 5.6.0 */
+    public ?int $accountability_partner_id = null;
+
+    /** @var int|null Share progress with partner (0/1) @since 5.6.0 */
+    public ?int $share_progress = 0;
+
     /** @var string|null @since 5.2.0 */
     public ?string $created = null;
 
@@ -98,7 +104,7 @@ class CwmuserTable extends Table
     #[\Override]
     public function bind($src, $ignore = ''): bool
     {
-        foreach (['id', 'user_id', 'plan_id', 'email', 'plan_view', 'date_offset'] as $field) {
+        foreach (['id', 'user_id', 'plan_id', 'email', 'plan_view', 'date_offset', 'accountability_partner_id', 'share_progress'] as $field) {
             if (isset($src[$field])) {
                 $src[$field] = $src[$field] !== '' ? (int) $src[$field] : null;
             }

--- a/plg_task_livingword/language/en-GB/plg_task_livingword.ini
+++ b/plg_task_livingword/language/en-GB/plg_task_livingword.ini
@@ -1,4 +1,6 @@
 PLG_TASK_LIVINGWORD="Task - LivingWord Email Notifications"
-PLG_TASK_LIVINGWORD_XML_DESCRIPTION="Sends daily Bible reading email notifications to subscribed LivingWord users."
+PLG_TASK_LIVINGWORD_XML_DESCRIPTION="Sends daily Bible reading email notifications and weekly partner digests to subscribed LivingWord users."
 PLG_TASK_LIVINGWORD_EMAIL_TITLE="LivingWord: Send Daily Reading Emails"
 PLG_TASK_LIVINGWORD_EMAIL_DESC="Sends email notifications with today's Bible reading to all subscribed users."
+PLG_TASK_LIVINGWORD_PARTNER_DIGEST_TITLE="LivingWord: Send Weekly Partner Progress Digest"
+PLG_TASK_LIVINGWORD_PARTNER_DIGEST_DESC="Sends a weekly email summary of accountability partner reading progress to paired users."

--- a/plg_task_livingword/src/Extension/Livingword.php
+++ b/plg_task_livingword/src/Extension/Livingword.php
@@ -13,6 +13,8 @@ namespace CWM\Plugin\Task\Livingword\Extension;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmpartnerHelper;
+use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmscriptureHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
@@ -44,6 +46,10 @@ class Livingword extends CMSPlugin implements SubscriberInterface
         'livingword.email_notifications' => [
             'langConstPrefix' => 'PLG_TASK_LIVINGWORD_EMAIL',
             'method'          => 'sendEmailNotifications',
+        ],
+        'livingword.partner_digest' => [
+            'langConstPrefix' => 'PLG_TASK_LIVINGWORD_PARTNER_DIGEST',
+            'method'          => 'sendPartnerDigest',
         ],
     ];
 
@@ -142,6 +148,92 @@ class Livingword extends CMSPlugin implements SubscriberInterface
         }
 
         $this->logTask('Sent ' . $sent . ' email notifications.');
+
+        return Status::OK;
+    }
+
+    /**
+     * Send weekly partner progress digest emails.
+     *
+     * For each user who has a mutual accountability partner and email enabled,
+     * sends a summary of the partner's reading progress.
+     *
+     * @param   ExecuteTaskEvent  $event  The task event
+     *
+     * @return  int  Task status code
+     *
+     * @since   5.6.0
+     */
+    private function sendPartnerDigest(ExecuteTaskEvent $event): int
+    {
+        $db       = $this->getDatabase();
+        $siteName = $this->getApplication()->get('sitename');
+        $pairs    = CwmpartnerHelper::getPartnerPairsForEmail($db);
+        $sent     = 0;
+
+        foreach ($pairs as $userRow) {
+            $userId    = (int) $userRow->user_id;
+            $partnerId = (int) $userRow->accountability_partner_id;
+
+            // Only send if mutual partnership
+            if (!CwmpartnerHelper::isMutualPartnership($db, $userId, $partnerId)) {
+                continue;
+            }
+
+            // Get partner's progress
+            $partnerProgress = CwmpartnerHelper::getPartnerProgress($db, $userId);
+
+            if (!$partnerProgress || !$partnerProgress->shares_progress) {
+                continue;
+            }
+
+            // Build email body
+            $body = '<h2>Your Accountability Partner\'s Progress</h2>'
+                  . '<p><strong>' . htmlspecialchars($partnerProgress->partner_name, ENT_QUOTES, 'UTF-8') . '</strong></p>'
+                  . '<table style="border-collapse:collapse;margin:10px 0;">'
+                  . '<tr><td style="padding:4px 12px 4px 0;">Plan:</td>'
+                  . '<td>' . htmlspecialchars($partnerProgress->plan_name, ENT_QUOTES, 'UTF-8') . '</td></tr>'
+                  . '<tr><td style="padding:4px 12px 4px 0;">Progress:</td>'
+                  . '<td>' . $partnerProgress->completed_count . ' of ' . $partnerProgress->total_days
+                  . ' readings (' . $partnerProgress->progress_percent . '%)</td></tr>'
+                  . '<tr><td style="padding:4px 12px 4px 0;">Current Day:</td>'
+                  . '<td>Day ' . $partnerProgress->current_day . '</td></tr>'
+                  . '<tr><td style="padding:4px 12px 4px 0;">Current Streak:</td>'
+                  . '<td>' . $partnerProgress->streak_current . ' days</td></tr>'
+                  . '<tr><td style="padding:4px 12px 4px 0;">Best Streak:</td>'
+                  . '<td>' . $partnerProgress->streak_best . ' days</td></tr>'
+                  . '</table>'
+                  . '<p>From ' . htmlspecialchars($siteName, ENT_QUOTES, 'UTF-8') . '</p>';
+
+            // Add unsubscribe footer
+            $token = CwmuserHelper::ensureUnsubscribeToken($db, $userId);
+            $unsubscribeUrl = CwmuserHelper::getUnsubscribeUrl($token);
+
+            $body .= '<hr style="margin-top:20px;border:none;border-top:1px solid #ccc;">'
+                   . '<p style="font-size:0.85em;color:#666;">'
+                   . '<a href="' . htmlspecialchars($unsubscribeUrl, ENT_QUOTES, 'UTF-8') . '">'
+                   . 'Unsubscribe from emails</a></p>';
+
+            try {
+                $mailer = $this->getApplication()->getContainer()->get(MailerFactoryInterface::class)->createMailer();
+                $mailer->addRecipient($userRow->user_email, $userRow->name);
+                $mailer->setSubject($siteName . ' - Your Partner\'s Reading Progress');
+                $mailer->setBody($body);
+                $mailer->isHtml(true);
+
+                $mailer->addCustomHeader('List-Unsubscribe', '<' . $unsubscribeUrl . '>');
+                $mailer->addCustomHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+
+                $mailer->send();
+                $sent++;
+            } catch (\Exception $e) {
+                $this->getApplication()->getLogger()->error(
+                    'LivingWord partner digest failed for user ' . $userId . ': ' . $e->getMessage()
+                );
+            }
+        }
+
+        $this->logTask('Sent ' . $sent . ' partner digest emails.');
 
         return Status::OK;
     }

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -57,6 +57,15 @@ COM_LIVINGWORD_UNSUBSCRIBE_SUCCESS="You have been successfully unsubscribed from
 COM_LIVINGWORD_UNSUBSCRIBE_INVALID="This unsubscribe link is invalid or has already been used."
 COM_LIVINGWORD_UNSUBSCRIBE_RESUBSCRIBE="Changed your mind? Log in and re-enable email notifications in your preferences."
 
+; Accountability partner
+COM_LIVINGWORD_PARTNER="Accountability Partner"
+COM_LIVINGWORD_PARTNER_DESC="Pair with another reader to encourage each other. Both users must select each other and enable sharing."
+COM_LIVINGWORD_PARTNER_SELECT="Select Partner"
+COM_LIVINGWORD_PARTNER_NONE="— No Partner —"
+COM_LIVINGWORD_PARTNER_SHARE="Share my reading progress with my partner"
+COM_LIVINGWORD_PARTNER_PROGRESS_TITLE="%s's Reading Progress"
+COM_LIVINGWORD_PARTNER_NOT_SHARING="%s has not enabled progress sharing yet."
+
 ; Audio player
 COM_LIVINGWORD_AUDIO_PLAY="Play Audio Bible"
 COM_LIVINGWORD_AUDIO_PAUSE="Pause"

--- a/site/src/Helper/CwmpartnerHelper.php
+++ b/site/src/Helper/CwmpartnerHelper.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Livingword\Site\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Accountability partner helper.
+ *
+ * Manages pairing between two users and exposes partner progress data.
+ * Partnership is opt-in: both users must set each other as partners
+ * AND enable share_progress for mutual visibility.
+ *
+ * @since  5.6.0
+ */
+class CwmpartnerHelper
+{
+    /**
+     * Get partner information for a user, including the partner's progress.
+     *
+     * Returns null if no partner is set or partner doesn't share progress.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  The current user's Joomla ID
+     *
+     * @return  ?object  Partner data with progress, or null
+     *
+     * @since   5.6.0
+     */
+    public static function getPartnerProgress(DatabaseInterface $db, int $userId): ?object
+    {
+        if ($userId === 0) {
+            return null;
+        }
+
+        // Get current user's partner setting
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['accountability_partner_id', 'share_progress']))
+            ->from($db->quoteName('#__livingword_users'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId);
+
+        $db->setQuery($query);
+        $myRow = $db->loadObject();
+
+        if (!$myRow || empty($myRow->accountability_partner_id)) {
+            return null;
+        }
+
+        $partnerId = (int) $myRow->accountability_partner_id;
+
+        // Get partner's LivingWord data + Joomla user name
+        $query = $db->getQuery(true)
+            ->select('lw.*, u.name AS partner_name')
+            ->from($db->quoteName('#__livingword_users', 'lw'))
+            ->join('INNER', $db->quoteName('#__users', 'u') . ' ON ' . $db->quoteName('u.id') . ' = ' . $db->quoteName('lw.user_id'))
+            ->where($db->quoteName('lw.user_id') . ' = ' . $partnerId);
+
+        $db->setQuery($query);
+        $partner = $db->loadObject();
+
+        if (!$partner) {
+            return null;
+        }
+
+        // Partner must also share progress for us to see it
+        if (!(int) $partner->share_progress) {
+            return (object) [
+                'partner_name'    => $partner->partner_name,
+                'partner_id'      => $partnerId,
+                'shares_progress' => false,
+                'is_mutual'       => self::isMutualPartnership($db, $userId, $partnerId),
+            ];
+        }
+
+        // Check if this is a mutual partnership
+        $isMutual = self::isMutualPartnership($db, $userId, $partnerId);
+
+        // Get partner's progress stats
+        $planId     = (int) $partner->plan_id;
+        $totalDays  = CwmreadingHelper::getPlanTotalDays($db, $planId);
+        $currentDay = CwmreadingHelper::getCurrentReadingDay(
+            $partner->start_date ?? '',
+            (int) $partner->date_offset,
+            $totalDays ?: 365
+        );
+        $completedCount  = CwmprogressHelper::getCompletedCount($db, $partnerId, $planId);
+        $progressPercent = ($totalDays > 0) ? round(($completedCount / $totalDays) * 100) : 0;
+
+        // Get plan name
+        $planInfo = CwmreadingHelper::getPlanById($db, $planId);
+
+        return (object) [
+            'partner_name'     => $partner->partner_name,
+            'partner_id'       => $partnerId,
+            'shares_progress'  => true,
+            'is_mutual'        => $isMutual,
+            'plan_name'        => $planInfo->description ?? '',
+            'current_day'      => $currentDay,
+            'total_days'       => $totalDays,
+            'completed_count'  => $completedCount,
+            'progress_percent' => $progressPercent,
+            'streak_current'   => (int) ($partner->streak_current ?? 0),
+            'streak_best'      => (int) ($partner->streak_best ?? 0),
+        ];
+    }
+
+    /**
+     * Check if two users have a mutual partnership (both point to each other).
+     *
+     * @param   DatabaseInterface  $db       Database instance
+     * @param   int                $userId   First user ID
+     * @param   int                $partnerId  Second user ID
+     *
+     * @return  bool
+     *
+     * @since   5.6.0
+     */
+    public static function isMutualPartnership(DatabaseInterface $db, int $userId, int $partnerId): bool
+    {
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('accountability_partner_id'))
+            ->from($db->quoteName('#__livingword_users'))
+            ->where($db->quoteName('user_id') . ' = ' . $partnerId);
+
+        $db->setQuery($query);
+        $theirPartnerId = (int) $db->loadResult();
+
+        return $theirPartnerId === $userId;
+    }
+
+    /**
+     * Get a list of LivingWord users for the partner selection dropdown.
+     *
+     * Excludes the current user. Only returns users who have a LivingWord record.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Current user ID to exclude
+     *
+     * @return  array  Array of objects with id and name
+     *
+     * @since   5.6.0
+     */
+    public static function getAvailablePartners(DatabaseInterface $db, int $userId): array
+    {
+        $query = $db->getQuery(true)
+            ->select('u.id, u.name')
+            ->from($db->quoteName('#__livingword_users', 'lw'))
+            ->join('INNER', $db->quoteName('#__users', 'u') . ' ON ' . $db->quoteName('u.id') . ' = ' . $db->quoteName('lw.user_id'))
+            ->where($db->quoteName('lw.user_id') . ' != ' . $userId)
+            ->where($db->quoteName('u.block') . ' = 0')
+            ->order($db->quoteName('u.name') . ' ASC');
+
+        $db->setQuery($query);
+
+        return $db->loadObjectList() ?: [];
+    }
+
+    /**
+     * Get partner progress summary data for email digest.
+     *
+     * Returns progress for all users who have a mutual partner and share progress.
+     *
+     * @param   DatabaseInterface  $db  Database instance
+     *
+     * @return  array  Array of objects with user + partner progress data
+     *
+     * @since   5.6.0
+     */
+    public static function getPartnerPairsForEmail(DatabaseInterface $db): array
+    {
+        // Get all users who have a partner set and share progress
+        $query = $db->getQuery(true)
+            ->select('lw.user_id, lw.accountability_partner_id, lw.plan_id, lw.start_date, lw.date_offset')
+            ->select('lw.streak_current, lw.streak_best, lw.share_progress')
+            ->select('u.name, u.email AS user_email')
+            ->from($db->quoteName('#__livingword_users', 'lw'))
+            ->join('INNER', $db->quoteName('#__users', 'u') . ' ON ' . $db->quoteName('u.id') . ' = ' . $db->quoteName('lw.user_id'))
+            ->where($db->quoteName('lw.accountability_partner_id') . ' IS NOT NULL')
+            ->where($db->quoteName('lw.email') . ' = 1')
+            ->where($db->quoteName('u.block') . ' = 0');
+
+        $db->setQuery($query);
+
+        return $db->loadObjectList() ?: [];
+    }
+}

--- a/site/src/Model/CwmhomeModel.php
+++ b/site/src/Model/CwmhomeModel.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmpartnerHelper;
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
@@ -67,6 +68,12 @@ class CwmhomeModel extends BaseDatabaseModel
 
         $progressPercent = ($totalDays > 0) ? round(($completedCount / $totalDays) * 100) : 0;
 
+        $partnerProgress = null;
+
+        if ($userId > 0) {
+            $partnerProgress = CwmpartnerHelper::getPartnerProgress($db, $userId);
+        }
+
         return (object) [
             'userData'          => $userData,
             'todayReading'      => $todayReading,
@@ -79,6 +86,7 @@ class CwmhomeModel extends BaseDatabaseModel
             'passages'          => $passages,
             'passageCount'      => $passageCount,
             'completedPassages' => $completedPassages,
+            'partnerProgress'   => $partnerProgress,
         ];
     }
 }

--- a/site/src/Model/CwmsettingsModel.php
+++ b/site/src/Model/CwmsettingsModel.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmpartnerHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Factory;
@@ -40,6 +41,21 @@ class CwmsettingsModel extends BaseDatabaseModel
         $userId = (int) Factory::getApplication()->getIdentity()->id;
 
         return CwmuserHelper::getUserData($db, $userId);
+    }
+
+    /**
+     * Get available accountability partners for dropdown.
+     *
+     * @return  array  Array of user objects with id and name
+     *
+     * @since   5.6.0
+     */
+    public function getAvailablePartners(): array
+    {
+        $db     = $this->getDatabase();
+        $userId = (int) Factory::getApplication()->getIdentity()->id;
+
+        return CwmpartnerHelper::getAvailablePartners($db, $userId);
     }
 
     /**
@@ -107,14 +123,20 @@ class CwmsettingsModel extends BaseDatabaseModel
             }
         }
 
+        $partnerId = !empty($data['accountability_partner_id'])
+            ? (int) $data['accountability_partner_id']
+            : null;
+
         $settings = (object) [
-            'user_id'       => $userId,
-            'plan_id'       => $planId,
-            'bible_version' => $data['bible_version'] ?? 'kjv',
-            'email'         => (int) ($data['email'] ?? 0),
-            'plan_view'     => (int) ($data['plan_view'] ?? 0),
-            'start_date'    => $startDate,
-            'date_offset'   => $dateOffset,
+            'user_id'                   => $userId,
+            'plan_id'                   => $planId,
+            'bible_version'             => $data['bible_version'] ?? 'kjv',
+            'email'                     => (int) ($data['email'] ?? 0),
+            'plan_view'                 => (int) ($data['plan_view'] ?? 0),
+            'start_date'                => $startDate,
+            'date_offset'               => $dateOffset,
+            'accountability_partner_id' => $partnerId,
+            'share_progress'            => (int) ($data['share_progress'] ?? 0),
         ];
 
         return CwmuserHelper::saveUserData($db, $settings);

--- a/site/src/View/Cwmsettings/HtmlView.php
+++ b/site/src/View/Cwmsettings/HtmlView.php
@@ -32,6 +32,9 @@ class HtmlView extends BaseHtmlView
     /** @var array @since 5.0.0 */
     protected array $plans = [];
 
+    /** @var array @since 5.6.0 */
+    protected array $availablePartners = [];
+
     /** @var string @since 5.0.0 */
     protected string $menu = '';
 
@@ -48,9 +51,10 @@ class HtmlView extends BaseHtmlView
     {
         $model = $this->getModel();
 
-        $this->userSettings = $model->getUserSettings();
-        $this->plans        = $model->getAvailablePlans();
-        $this->menu         = CwmmenuHelper::buildMenu();
+        $this->userSettings      = $model->getUserSettings();
+        $this->plans             = $model->getAvailablePlans();
+        $this->availablePartners = $model->getAvailablePartners();
+        $this->menu              = CwmmenuHelper::buildMenu();
 
         $this->prepareDocument();
 

--- a/site/tmpl/cwmhome/default.php
+++ b/site/tmpl/cwmhome/default.php
@@ -211,5 +211,45 @@ if ($showAudio && $reading) {
                 <?php echo Text::_('COM_LIVINGWORD_VIEW_FULL_PLAN'); ?>
             </a>
         </div>
+
+        <?php
+        $partner = $data->partnerProgress ?? null;
+        if ($partner && $partner->shares_progress && $partner->is_mutual) : ?>
+            <div class="card mt-4">
+                <div class="card-body">
+                    <h5 class="card-title"><?php echo Text::sprintf('COM_LIVINGWORD_PARTNER_PROGRESS_TITLE', $this->escape($partner->partner_name)); ?></h5>
+                    <p class="mb-1">
+                        <?php echo $this->escape($partner->plan_name); ?>
+                        &mdash; <?php echo Text::sprintf('COM_LIVINGWORD_DAY_OF', $partner->current_day, $partner->total_days); ?>
+                    </p>
+                    <?php if ($partner->total_days > 0) : ?>
+                        <div class="progress mb-2" style="height: 8px;" role="progressbar"
+                             aria-valuenow="<?php echo $partner->progress_percent; ?>" aria-valuemin="0" aria-valuemax="100">
+                            <div class="progress-bar bg-info" style="width: <?php echo $partner->progress_percent; ?>%"></div>
+                        </div>
+                        <div class="d-flex justify-content-between">
+                            <small class="text-muted">
+                                <?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_DAYS', $partner->completed_count, $partner->total_days); ?>
+                                (<?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_PERCENT', $partner->progress_percent); ?>)
+                            </small>
+                            <?php if ($partner->streak_current > 0) : ?>
+                                <small class="text-muted">
+                                    <?php echo Text::sprintf('COM_LIVINGWORD_STREAK_CURRENT', $partner->streak_current); ?>
+                                </small>
+                            <?php endif; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php elseif ($partner && !$partner->shares_progress) : ?>
+            <div class="card mt-4">
+                <div class="card-body">
+                    <h5 class="card-title"><?php echo Text::_('COM_LIVINGWORD_PARTNER'); ?></h5>
+                    <p class="text-muted mb-0">
+                        <?php echo Text::sprintf('COM_LIVINGWORD_PARTNER_NOT_SHARING', $this->escape($partner->partner_name)); ?>
+                    </p>
+                </div>
+            </div>
+        <?php endif; ?>
     </div>
 </div>

--- a/site/tmpl/cwmsettings/default.php
+++ b/site/tmpl/cwmsettings/default.php
@@ -18,8 +18,9 @@ use Joomla\CMS\Router\Route;
 
 /** @var \CWM\Component\Livingword\Site\View\Cwmsettings\HtmlView $this */
 
-$user  = $this->userSettings;
-$plans = $this->plans;
+$user     = $this->userSettings;
+$plans    = $this->plans;
+$partners = $this->availablePartners;
 
 // Calculate current position for display
 $planId   = (int) ($user->plan_id ?? 0);
@@ -115,6 +116,30 @@ if ($planId > 0) {
                         </div>
                     <?php endif; ?>
                 <?php endif; ?>
+
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title"><?php echo Text::_('COM_LIVINGWORD_PARTNER'); ?></h5>
+                        <p class="text-muted small"><?php echo Text::_('COM_LIVINGWORD_PARTNER_DESC'); ?></p>
+
+                        <div class="mb-3">
+                            <label for="accountability_partner_id" class="form-label"><?php echo Text::_('COM_LIVINGWORD_PARTNER_SELECT'); ?></label>
+                            <select name="accountability_partner_id" id="accountability_partner_id" class="form-select">
+                                <option value=""><?php echo Text::_('COM_LIVINGWORD_PARTNER_NONE'); ?></option>
+                                <?php foreach ($partners as $partner) : ?>
+                                    <option value="<?php echo (int) $partner->id; ?>"<?php echo (int) ($user->accountability_partner_id ?? 0) === (int) $partner->id ? ' selected' : ''; ?>>
+                                        <?php echo $this->escape($partner->name); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+
+                        <div class="mb-0 form-check">
+                            <input type="checkbox" name="share_progress" id="share_progress" class="form-check-input" value="1"<?php echo (int) ($user->share_progress ?? 0) ? ' checked' : ''; ?>>
+                            <label for="share_progress" class="form-check-label"><?php echo Text::_('COM_LIVINGWORD_PARTNER_SHARE'); ?></label>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Pair two LivingWord users as accountability partners who can view each other's reading progress
- Partnership is opt-in: both users must select each other AND enable "Share my progress" for mutual visibility
- Weekly partner progress digest email via the task scheduler plugin

## Changes
- **Schema:** Added `accountability_partner_id` and `share_progress` columns to `#__livingword_users` (migration `5.6.0.sql`)
- **CwmpartnerHelper:** New helper with partner progress retrieval, mutual partnership check, available partners dropdown, and email pair queries
- **Settings page:** Partner selection dropdown + sharing toggle in a new card
- **Home view:** Partner progress card showing plan, day, completion %, and streak when both users share
- **Task plugin:** New `livingword.partner_digest` task type for weekly partner progress emails with unsubscribe support
- **Language:** Added 8 new language constants for partner UI

## How it works
1. User A goes to Settings → selects User B as partner → enables "Share my progress"
2. User B does the same, selecting User A
3. Both users now see each other's progress card on their home view
4. If only one side shares, the other sees a "not sharing yet" message
5. Weekly digest emails sent to paired users via scheduled task

## Test plan
- [ ] Run migration `5.6.0.sql` on existing database
- [ ] Settings page: verify partner dropdown shows other LivingWord users
- [ ] Select a partner and enable sharing — save settings
- [ ] Have the partner do the same — verify mutual partnership
- [ ] Home view: verify partner progress card appears with correct stats
- [ ] Remove partner or disable sharing — verify card updates accordingly
- [ ] One-sided partnership: verify "not sharing" message shows
- [ ] Task plugin: verify partner digest task type appears in Joomla scheduler

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)