### PR TITLE
Fix functional errors found in code audit

### DIFF
--- a/admin/src/Controller/CwmutilitiesController.php
+++ b/admin/src/Controller/CwmutilitiesController.php
@@ -202,41 +202,46 @@ class CwmutilitiesController extends BaseController
         $errors   = 0;
         $lineNum  = 0;
 
-        while (($row = fgetcsv($handle)) !== false) {
-            $lineNum++;
+        try {
+            $db->transactionStart();
 
-            // Skip header row if present
-            if ($lineNum === 1 && isset($row[0]) && strtolower(trim($row[0])) === 'day_number') {
-                continue;
-            }
+            while (($row = fgetcsv($handle)) !== false) {
+                $lineNum++;
 
-            // Minimum: reading reference in column index 1 (or 0 if no day_number)
-            $reading = trim($row[1] ?? $row[0] ?? '');
+                // Skip header row if present
+                if ($lineNum === 1 && isset($row[0]) && strtolower(trim($row[0])) === 'day_number') {
+                    continue;
+                }
 
-            if (empty($reading)) {
-                $errors++;
+                // Minimum: reading reference in column index 1 (or 0 if no day_number)
+                $reading = trim($row[1] ?? $row[0] ?? '');
 
-                continue;
-            }
+                if (empty($reading)) {
+                    $errors++;
 
-            $audio   = trim($row[2] ?? '');
-            $descrip = trim($row[3] ?? '');
+                    continue;
+                }
 
-            $record = (object) [
-                'plan_id'  => $planId,
-                'ordering' => $ordering,
-                'reading'  => $reading,
-                'audio'    => $audio,
-                'descrip'  => $descrip,
-            ];
+                $audio   = trim($row[2] ?? '');
+                $descrip = trim($row[3] ?? '');
 
-            try {
+                $record = (object) [
+                    'plan_id'  => $planId,
+                    'ordering' => $ordering,
+                    'reading'  => $reading,
+                    'audio'    => $audio,
+                    'descrip'  => $descrip,
+                ];
+
                 $db->insertObject('#__livingword_plans_details', $record);
                 $imported++;
                 $ordering++;
-            } catch (\RuntimeException $e) {
-                $errors++;
             }
+
+            $db->transactionCommit();
+        } catch (\RuntimeException $e) {
+            $db->transactionRollback();
+            $errors++;
         }
 
         fclose($handle);

--- a/admin/src/View/Cwmutilities/HtmlView.php
+++ b/admin/src/View/Cwmutilities/HtmlView.php
@@ -14,9 +14,11 @@ namespace CWM\Component\Livingword\Administrator\View\Cwmutilities;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * Utilities view (database maintenance)
@@ -25,6 +27,9 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  */
 class HtmlView extends BaseHtmlView
 {
+    /** @var array Available plans for CSV import @since 5.8.0 */
+    protected array $plans = [];
+
     /**
      * @param   string  $tpl  Template name.
      *
@@ -36,6 +41,15 @@ class HtmlView extends BaseHtmlView
     #[\Override]
     public function display($tpl = null): void
     {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['id', 'title']))
+            ->from($db->quoteName('#__livingword_plans'))
+            ->where($db->quoteName('published') . ' = 1')
+            ->order($db->quoteName('ordering') . ' ASC');
+        $db->setQuery($query);
+        $this->plans = $db->loadObjectList() ?: [];
+
         $this->addToolbar();
 
         parent::display($tpl);

--- a/admin/tmpl/cwmutilities/default.php
+++ b/admin/tmpl/cwmutilities/default.php
@@ -71,17 +71,7 @@ $token = Session::getFormToken();
                         <label for="plan_id" class="form-label"><?php echo Text::_('COM_LIVINGWORD_CSV_SELECT_PLAN'); ?></label>
                         <select name="plan_id" id="csv_plan_id" class="form-select" required>
                             <option value=""><?php echo Text::_('COM_LIVINGWORD_SELECT_PLAN'); ?></option>
-                            <?php
-                            $db    = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
-                            $query = $db->getQuery(true)
-                                ->select($db->quoteName(['id', 'title']))
-                                ->from($db->quoteName('#__livingword_plans'))
-                                ->where($db->quoteName('published') . ' = 1')
-                                ->order($db->quoteName('ordering') . ' ASC');
-                            $db->setQuery($query);
-                            $plans = $db->loadObjectList() ?: [];
-
-                            foreach ($plans as $csvPlan) : ?>
+                            <?php foreach ($this->plans as $csvPlan) : ?>
                                 <option value="<?php echo (int) $csvPlan->id; ?>">
                                     <?php echo htmlspecialchars($csvPlan->title, ENT_QUOTES, 'UTF-8'); ?>
                                 </option>

--- a/media/com_livingword/js/livingword-progress.js
+++ b/media/com_livingword/js/livingword-progress.js
@@ -111,7 +111,7 @@
           // Update the passage text styling
           const passageItem = btn.closest('[data-livingword-passage]');
           if (passageItem) {
-            const lead = passageItem.querySelector('.lead');
+            const lead = passageItem.querySelector('.livingword-scripture-text, .lead, p');
             if (lead) {
               lead.classList.toggle('text-decoration-line-through', passageCompleted);
               lead.classList.toggle('text-muted', passageCompleted);
@@ -190,7 +190,7 @@
 
       const passageItem = btn.closest('[data-livingword-passage]');
       if (passageItem) {
-        const lead = passageItem.querySelector('.lead');
+        const lead = passageItem.querySelector('.livingword-scripture-text, .lead, p');
         if (lead) {
           lead.classList.toggle('text-decoration-line-through', completed);
           lead.classList.toggle('text-muted', completed);

--- a/site/src/Helper/CwmgroupHelper.php
+++ b/site/src/Helper/CwmgroupHelper.php
@@ -254,7 +254,7 @@ class CwmgroupHelper
 
         try {
             $db->insertObject('#__livingword_group_members', $record);
-        } catch (\RuntimeException) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/site/src/Helper/CwmpartnerHelper.php
+++ b/site/src/Helper/CwmpartnerHelper.php
@@ -106,7 +106,7 @@ class CwmpartnerHelper
             'partner_id'       => $partnerId,
             'shares_progress'  => true,
             'is_mutual'        => $isMutual,
-            'plan_name'        => $planInfo->description ?? '',
+            'plan_name'        => ($planInfo !== null) ? ($planInfo->description ?? '') : '',
             'current_day'      => $currentDay,
             'total_days'       => $totalDays,
             'completed_count'  => $completedCount,

--- a/site/src/Helper/CwmscriptureHelper.php
+++ b/site/src/Helper/CwmscriptureHelper.php
@@ -73,9 +73,13 @@ class CwmscriptureHelper
                 continue;
             }
 
-            $result = $provider->getPassage($passage, $version);
+            try {
+                $result = $provider->getPassage($passage, $version);
+            } catch (\Exception) {
+                continue;
+            }
 
-            if ($result->hasText()) {
+            if ($result !== null && $result->hasText()) {
                 $allText[] = '<div class="scripture-passage">'
                     . '<h4>' . htmlspecialchars($passage, ENT_QUOTES, 'UTF-8') . '</h4>'
                     . $result->text
@@ -310,9 +314,13 @@ class CwmscriptureHelper
             $chapters = self::expandChapterRange($passage, $parsed['chapter']);
 
             foreach ($chapters as $chapter) {
-                $result = $provider->getAudio($parsed['book'], $chapter, $version);
+                try {
+                    $result = $provider->getAudio($parsed['book'], $chapter, $version);
+                } catch (\Exception) {
+                    continue;
+                }
 
-                if ($result->hasAudio()) {
+                if ($result !== null && $result->hasAudio()) {
                     $audioList[] = (object) [
                         'audioUrl'    => $result->getPrimaryUrl(),
                         'book'        => $result->book,


### PR DESCRIPTION
## Summary
Fixes critical and high-priority issues identified during a comprehensive code audit of all helpers, controllers, models, templates, and JavaScript.

## Fixes

### Null Safety
- **CwmpartnerHelper**: Null check on `$planInfo` before accessing `->description` (crash if partner's plan deleted)
- **CwmscriptureHelper**: Null check on provider results before calling `->hasText()` and `->hasAudio()`

### Exception Handling
- **getPassageText()**: Try-catch around scripture provider calls — failed passages are skipped instead of crashing the page
- **getAudioForReading()**: Try-catch around audio provider calls per chapter — network/API errors handled gracefully
- **CwmgroupHelper::joinGroup()**: Catch `\Exception` instead of just `\RuntimeException`

### Transaction Integrity
- **CSV import**: Insert loop wrapped in `transactionStart()`/`transactionCommit()` with `transactionRollback()` on failure — prevents orphaned partial imports

### MVC Pattern
- **Utilities view**: Plans query moved from template into `HtmlView::display()` — template now uses `$this->plans`

### JavaScript
- **Progress toggle**: Broadened selector from `.lead` to `.livingword-scripture-text, .lead, p` — matches redesigned template structure where `.lead` class no longer exists

## Not fixed (accepted risk)
- Integer concatenation in SQL queries: all values are typed as `int`, Joomla convention
- `$plan->message` and `$reading->descrip` rendered as raw HTML: intentional rich text fields with `safehtml` filter on input
- Streak race condition: low probability, would require same user completing two readings simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)