### PR TITLE
Hide admin sidebar on Utilities view, add Back button

### DIFF
--- a/admin/src/View/Cwmutilities/HtmlView.php
+++ b/admin/src/View/Cwmutilities/HtmlView.php
@@ -62,6 +62,9 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
+
         ToolbarHelper::title(Text::_('COM_LIVINGWORD_UTILITIES'), 'wrench');
+        ToolbarHelper::back('JTOOLBAR_BACK', 'index.php?option=com_livingword');
     }
 }


### PR DESCRIPTION
Utilities now behaves like an edit view — sidebar hidden, Back button returns to cpanel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)