### PR TITLE
Fix config plan field: use text instead of sql type

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -5,9 +5,9 @@
                label="COM_LIVINGWORD_CONFIG_STARTDATE" description="COM_LIVINGWORD_CONFIG_STARTDATE_DESC" />
         <field name="config_bible_version" type="text" default="kjv"
                label="COM_LIVINGWORD_CONFIG_VERSION" description="COM_LIVINGWORD_CONFIG_VERSION_DESC" />
-        <field name="config_bible_plan" type="sql" default="comp"
+        <field name="config_bible_plan" type="text" default="comp"
                label="COM_LIVINGWORD_CONFIG_PLAN" description="COM_LIVINGWORD_CONFIG_PLAN_DESC"
-               query="SELECT alias AS value, title AS text FROM #__livingword_plans WHERE published = 1 ORDER BY ordering" />
+               hint="e.g. comp, newtest, bio" size="20" maxlength="50" />
         <field name="config_plan_template" type="list" default="calendar" validate="options"
                label="COM_LIVINGWORD_CONFIG_PLAN_TEMPLATE" description="COM_LIVINGWORD_CONFIG_PLAN_TEMPLATE_DESC">
             <option value="default">COM_LIVINGWORD_CONFIG_TEMPLATE_LIST</option>


### PR DESCRIPTION
Joomla 6 SqlField has issues in component config. Switch to text with alias hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)