### PR TITLE
Replace config text fields with proper dropdown selectors

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<config>
+<config addfieldprefix="CWM\Component\Livingword\Administrator\Field">
     <fieldset name="general_settings" label="COM_LIVINGWORD_CONFIG_GENERAL">
         <field name="config_global_startdate" type="calendar" default="NOW" filter="server_utc" format="%Y-%m-%d"
                label="COM_LIVINGWORD_CONFIG_STARTDATE" description="COM_LIVINGWORD_CONFIG_STARTDATE_DESC" />
-        <field name="config_bible_version" type="text" default="kjv"
+        <field name="config_bible_version" type="BibleVersion" default="kjv"
                label="COM_LIVINGWORD_CONFIG_VERSION" description="COM_LIVINGWORD_CONFIG_VERSION_DESC" />
-        <field name="config_bible_plan" type="text" default="comp"
-               label="COM_LIVINGWORD_CONFIG_PLAN" description="COM_LIVINGWORD_CONFIG_PLAN_DESC"
-               hint="e.g. comp, newtest, bio" size="20" maxlength="50" />
+        <field name="config_bible_plan" type="Plan" default="comp"
+               label="COM_LIVINGWORD_CONFIG_PLAN" description="COM_LIVINGWORD_CONFIG_PLAN_DESC" />
         <field name="config_plan_template" type="list" default="calendar" validate="options"
                label="COM_LIVINGWORD_CONFIG_PLAN_TEMPLATE" description="COM_LIVINGWORD_CONFIG_PLAN_TEMPLATE_DESC">
             <option value="default">COM_LIVINGWORD_CONFIG_TEMPLATE_LIST</option>
@@ -34,9 +33,10 @@
             <option value="0">JNO</option>
             <option value="1">JYES</option>
         </field>
-        <field name="config_audio_default_version" type="text" default=""
-               label="COM_LIVINGWORD_CONFIG_AUDIO_VERSION" description="COM_LIVINGWORD_CONFIG_AUDIO_VERSION_DESC"
-               hint="COM_LIVINGWORD_PLAN_AUDIO_VERSION_HINT" size="20" maxlength="20" />
+        <field name="config_audio_default_version" type="BibleVersion" default=""
+               label="COM_LIVINGWORD_CONFIG_AUDIO_VERSION" description="COM_LIVINGWORD_CONFIG_AUDIO_VERSION_DESC">
+            <option value="">COM_LIVINGWORD_PARTNER_NONE</option>
+        </field>
     </fieldset>
     <fieldset name="menu_settings" label="COM_LIVINGWORD_CONFIG_MENU">
         <field name="config_show_menu" type="radio" layout="joomla.form.field.radio.switcher" default="1"

--- a/admin/src/Field/BibleVersionField.php
+++ b/admin/src/Field/BibleVersionField.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @package    Livingword.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Administrator\Field;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Form\Field\ListField;
+
+/**
+ * Dropdown field listing common Bible translation codes.
+ *
+ * @since  5.8.0
+ */
+class BibleVersionField extends ListField
+{
+    /** @var string @since 5.8.0 */
+    protected $type = 'BibleVersion';
+
+    /**
+     * Common Bible translations used with BibleGateway and BibleBrain.
+     *
+     * @var array
+     * @since 5.8.0
+     */
+    private const VERSIONS = [
+        'kjv'  => 'King James Version (KJV)',
+        'nkjv' => 'New King James Version (NKJV)',
+        'niv'  => 'New International Version (NIV)',
+        'esv'  => 'English Standard Version (ESV)',
+        'nlt'  => 'New Living Translation (NLT)',
+        'nasb' => 'New American Standard Bible (NASB)',
+        'amp'  => 'Amplified Bible (AMP)',
+        'csb'  => 'Christian Standard Bible (CSB)',
+        'web'  => 'World English Bible (WEB)',
+        'msg'  => 'The Message (MSG)',
+    ];
+
+    /**
+     * @return  array
+     *
+     * @since   5.8.0
+     */
+    #[\Override]
+    protected function getOptions(): array
+    {
+        $options = parent::getOptions();
+
+        foreach (self::VERSIONS as $code => $label) {
+            $options[] = (object) ['value' => $code, 'text' => $label];
+        }
+
+        return $options;
+    }
+}

--- a/admin/src/Field/PlanField.php
+++ b/admin/src/Field/PlanField.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @package    Livingword.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Administrator\Field;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Dropdown field listing published reading plans by alias.
+ *
+ * @since  5.8.0
+ */
+class PlanField extends ListField
+{
+    /** @var string @since 5.8.0 */
+    protected $type = 'Plan';
+
+    /**
+     * @return  array
+     *
+     * @since   5.8.0
+     */
+    #[\Override]
+    protected function getOptions(): array
+    {
+        $options = parent::getOptions();
+
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('alias', 'value'))
+                ->select($db->quoteName('title', 'text'))
+                ->from($db->quoteName('#__livingword_plans'))
+                ->where($db->quoteName('published') . ' = 1')
+                ->order($db->quoteName('ordering') . ' ASC');
+            $db->setQuery($query);
+            $plans = $db->loadObjectList() ?: [];
+
+            foreach ($plans as $plan) {
+                $options[] = (object) ['value' => $plan->value, 'text' => $plan->text];
+            }
+        } catch (\Exception) {
+            // Table may not exist yet during install
+        }
+
+        return $options;
+    }
+}


### PR DESCRIPTION
## Summary
Config fields for bible plan, bible version, and audio version are now dropdowns instead of free text.

## Changes
- **PlanField** (`admin/src/Field/PlanField.php`): Queries `#__livingword_plans` for published plans, lists by alias/title
- **BibleVersionField** (`admin/src/Field/BibleVersionField.php`): Lists 10 common translations (KJV, NIV, ESV, NLT, etc.)
- **config.xml**: Uses custom field types via `addfieldprefix`, avoids Joomla 6 SqlField issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)