### PR TITLE
Add scripture system status check to admin cpanel

### DIFF
--- a/admin/language/en-GB/com_livingword.ini
+++ b/admin/language/en-GB/com_livingword.ini
@@ -184,11 +184,19 @@ COM_LIVINGWORD_CONFIG_SHOW_AUDIO_DESC="Show the audio Bible player on the readin
 COM_LIVINGWORD_CONFIG_AUDIO_VERSION="Default Audio Version"
 COM_LIVINGWORD_CONFIG_AUDIO_VERSION_DESC="Default BibleBrain audio fileset code used when plan and user don't specify one."
 
+; Scripture system status
+COM_LIVINGWORD_SCRIPTURE_STATUS="Scripture System"
+COM_LIVINGWORD_SCRIPTURE_LIBRARY_OK="Scripture Library Installed"
+COM_LIVINGWORD_SCRIPTURE_LIBRARY_OK_DESC="Inline Bible text, provider-based lookups, and audio are available."
+COM_LIVINGWORD_SCRIPTURE_LIBRARY_MISSING="Scripture Library Not Installed"
+COM_LIVINGWORD_SCRIPTURE_LIBRARY_MISSING_DESC="Install lib_cwmscripture to enable inline Bible text and audio playback. Readings will link to BibleGateway instead."
+
 ; Audio admin
-COM_LIVINGWORD_AUDIO_STATUS="Audio Bible Status"
+COM_LIVINGWORD_AUDIO_STATUS="Audio Bible"
 COM_LIVINGWORD_AUDIO_NO_LIBRARY="CWM Scripture Library not installed. Audio requires lib_cwmscripture."
 COM_LIVINGWORD_AUDIO_NO_KEY="BibleBrain not configured. Set API key in Scripture Library settings."
-COM_LIVINGWORD_AUDIO_CONFIGURED="BibleBrain audio is configured and ready."
+COM_LIVINGWORD_AUDIO_CONFIGURED="Audio Bible Ready"
+COM_LIVINGWORD_AUDIO_REQUIRES_LIBRARY="Requires Scripture Library"
 COM_LIVINGWORD_AUDIO_PLANS_ENABLED="%d plans with audio enabled"
 COM_LIVINGWORD_PLAN_TEST_AUDIO="Test Audio"
 COM_LIVINGWORD_PLAN_TEST_AUDIO_PLAYING="Playing sample (10 seconds)..."

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -100,20 +100,54 @@ if ($scriptureAvailable) {
         </div>
     </div>
 
-    <?php // ── Audio Status Card ── ?>
-    <div class="card mb-4 <?php echo $audioAvailable ? 'border-success' : 'border-warning'; ?>">
-        <div class="card-body d-flex align-items-center gap-3">
-            <span class="icon-music fa-2x <?php echo $audioAvailable ? 'text-success' : 'text-warning'; ?>" aria-hidden="true"></span>
-            <div class="flex-grow-1">
-                <h5 class="card-title mb-1"><?php echo Text::_('COM_LIVINGWORD_AUDIO_STATUS'); ?></h5>
-                <?php if (!$scriptureAvailable) : ?>
-                    <small class="text-muted"><?php echo Text::_('COM_LIVINGWORD_AUDIO_NO_LIBRARY'); ?></small>
-                <?php elseif (!$bbKeyConfigured) : ?>
-                    <small class="text-warning"><?php echo Text::_('COM_LIVINGWORD_AUDIO_NO_KEY'); ?></small>
-                <?php else : ?>
-                    <small class="text-success"><?php echo Text::_('COM_LIVINGWORD_AUDIO_CONFIGURED'); ?></small>
-                    <span class="ms-2 badge bg-info"><?php echo Text::sprintf('COM_LIVINGWORD_AUDIO_PLANS_ENABLED', $audioPlansCount); ?></span>
-                <?php endif; ?>
+    <?php // ── Scripture System Status ── ?>
+    <div class="card mb-4 <?php echo $scriptureAvailable ? ($audioAvailable ? 'border-success' : 'border-info') : 'border-warning'; ?>">
+        <div class="card-body">
+            <h5 class="card-title mb-3">
+                <span class="icon-book" aria-hidden="true"></span>
+                <?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_STATUS'); ?>
+            </h5>
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="d-flex align-items-start gap-2">
+                        <?php if ($scriptureAvailable) : ?>
+                            <span class="icon-checkmark-circle text-success fs-4" aria-hidden="true"></span>
+                            <div>
+                                <strong><?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_LIBRARY_OK'); ?></strong>
+                                <br><small class="text-muted"><?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_LIBRARY_OK_DESC'); ?></small>
+                            </div>
+                        <?php else : ?>
+                            <span class="icon-warning text-warning fs-4" aria-hidden="true"></span>
+                            <div>
+                                <strong><?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_LIBRARY_MISSING'); ?></strong>
+                                <br><small class="text-muted"><?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_LIBRARY_MISSING_DESC'); ?></small>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="d-flex align-items-start gap-2">
+                        <?php if ($audioAvailable) : ?>
+                            <span class="icon-checkmark-circle text-success fs-4" aria-hidden="true"></span>
+                            <div>
+                                <strong><?php echo Text::_('COM_LIVINGWORD_AUDIO_CONFIGURED'); ?></strong>
+                                <br><small class="text-muted"><?php echo Text::sprintf('COM_LIVINGWORD_AUDIO_PLANS_ENABLED', $audioPlansCount); ?></small>
+                            </div>
+                        <?php elseif ($scriptureAvailable && !$bbKeyConfigured) : ?>
+                            <span class="icon-info-circle text-info fs-4" aria-hidden="true"></span>
+                            <div>
+                                <strong><?php echo Text::_('COM_LIVINGWORD_AUDIO_STATUS'); ?></strong>
+                                <br><small class="text-muted"><?php echo Text::_('COM_LIVINGWORD_AUDIO_NO_KEY'); ?></small>
+                            </div>
+                        <?php else : ?>
+                            <span class="icon-minus-circle text-secondary fs-4" aria-hidden="true"></span>
+                            <div>
+                                <strong><?php echo Text::_('COM_LIVINGWORD_AUDIO_STATUS'); ?></strong>
+                                <br><small class="text-muted"><?php echo Text::_('COM_LIVINGWORD_AUDIO_REQUIRES_LIBRARY'); ?></small>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Two-column status card showing:
- **Scripture Library**: installed or missing, with impact description
- **Audio Bible**: configured, needs key, or requires library

Admins can immediately see what's set up and what needs attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)