### PR TITLE
Add configure links to scripture status card for admins

### DIFF
--- a/admin/language/en-GB/com_livingword.ini
+++ b/admin/language/en-GB/com_livingword.ini
@@ -190,6 +190,8 @@ COM_LIVINGWORD_SCRIPTURE_LIBRARY_OK="Scripture Library Installed"
 COM_LIVINGWORD_SCRIPTURE_LIBRARY_OK_DESC="Inline Bible text, provider-based lookups, and audio are available."
 COM_LIVINGWORD_SCRIPTURE_LIBRARY_MISSING="Scripture Library Not Installed"
 COM_LIVINGWORD_SCRIPTURE_LIBRARY_MISSING_DESC="Install lib_cwmscripture to enable inline Bible text and audio playback. Readings will link to BibleGateway instead."
+COM_LIVINGWORD_CONFIGURE="Configure"
+COM_LIVINGWORD_SCRIPTURE_SETTINGS="Scripture Settings"
 
 ; Audio admin
 COM_LIVINGWORD_AUDIO_STATUS="Audio Bible"

--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -101,12 +101,31 @@ if ($scriptureAvailable) {
     </div>
 
     <?php // ── Scripture System Status ── ?>
+    <?php $canAdmin = $this->canDo->get('core.admin'); ?>
     <div class="card mb-4 <?php echo $scriptureAvailable ? ($audioAvailable ? 'border-success' : 'border-info') : 'border-warning'; ?>">
         <div class="card-body">
-            <h5 class="card-title mb-3">
-                <span class="icon-book" aria-hidden="true"></span>
-                <?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_STATUS'); ?>
-            </h5>
+            <div class="d-flex justify-content-between align-items-start mb-3">
+                <h5 class="card-title mb-0">
+                    <span class="icon-book" aria-hidden="true"></span>
+                    <?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_STATUS'); ?>
+                </h5>
+                <?php if ($canAdmin) : ?>
+                    <div class="d-flex gap-2">
+                        <a href="<?php echo Route::_('index.php?option=com_config&view=component&component=com_livingword'); ?>"
+                           class="btn btn-sm btn-outline-secondary">
+                            <span class="icon-options" aria-hidden="true"></span>
+                            <?php echo Text::_('COM_LIVINGWORD_CONFIGURE'); ?>
+                        </a>
+                        <?php if ($scriptureAvailable) : ?>
+                            <a href="<?php echo Route::_('index.php?option=com_plugins&view=plugins&filter[search]=cwmscripture'); ?>"
+                               class="btn btn-sm btn-outline-secondary">
+                                <span class="icon-puzzle-piece" aria-hidden="true"></span>
+                                <?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_SETTINGS'); ?>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
+            </div>
             <div class="row g-3">
                 <div class="col-md-6">
                     <div class="d-flex align-items-start gap-2">


### PR DESCRIPTION
Admin users see Configure and Scripture Settings buttons in the status card. ACL-gated to core.admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)