### PR TITLE
Fix scripture plugin search filter name

### DIFF
--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -110,7 +110,7 @@ if ($scriptureAvailable) {
                     <?php echo Text::_('COM_LIVINGWORD_SCRIPTURE_STATUS'); ?>
                 </h5>
                 <?php if ($canAdmin) : ?>
-                    <a href="<?php echo Route::_('index.php?option=com_plugins&view=plugins&filter[search]=cwmscripture'); ?>"
+                    <a href="<?php echo Route::_('index.php?option=com_plugins&view=plugins&filter[search]=ScriptureLinks'); ?>"
                        target="_blank" rel="noopener"
                        class="btn btn-sm btn-outline-secondary">
                         <span class="icon-puzzle-piece" aria-hidden="true"></span>


### PR DESCRIPTION
Filter by 'ScriptureLinks' to match actual plugin name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)