### PR TITLE
Redesign calendar view as proper weekly grid with month navigation

### DIFF
--- a/media/com_livingword/css/livingword.css
+++ b/media/com_livingword/css/livingword.css
@@ -214,38 +214,102 @@
 }
 
 /* ── Calendar View ── */
-.livingword-calendar-grid {
-  gap: 4px;
+.livingword-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 3px;
 }
 
-@media (max-width: 575.98px) {
-  .livingword-calendar-grid {
-    --bs-columns: 4;
-  }
-
-  .livingword-calendar-card .card-body {
-    padding: 0.5rem;
-    font-size: 0.75rem;
-  }
+.livingword-cal-header {
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--bs-secondary-color, #6c757d);
+  padding: 0.4rem 0;
 }
 
-.livingword-calendar-card {
-  border-radius: 8px;
-  transition: transform 0.1s, box-shadow 0.1s;
+.livingword-cal-cell {
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 6px;
+  padding: 0.3rem;
+  min-height: 52px;
+  transition: transform 0.1s, box-shadow 0.1s, border-color 0.1s;
+  cursor: default;
 }
 
-.livingword-calendar-card:hover {
+.livingword-cal-cell:hover:not(.livingword-cal-empty) {
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  border-color: var(--bs-primary, #0d6efd);
 }
 
-.livingword-calendar-card .card-body {
-  padding: 0.35rem;
+.livingword-cal-empty {
+  border: none;
+  background: transparent;
 }
 
-.livingword-calendar-current {
+.livingword-cal-date {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  font-size: 0.8rem;
+  margin-bottom: 2px;
+}
+
+.livingword-cal-reading {
+  font-size: 0.65rem;
+  color: var(--bs-secondary-color, #6c757d);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Current day */
+.livingword-cal-today {
+  border-color: var(--bs-primary, #0d6efd);
   border-width: 2px;
-  box-shadow: 0 0 0 2px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.25);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.06);
+  box-shadow: 0 0 0 2px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.15);
+}
+
+.livingword-cal-today .livingword-cal-date {
+  color: var(--bs-primary, #0d6efd);
+}
+
+/* Completed day */
+.livingword-cal-complete {
+  border-color: var(--bs-success, #198754);
+  background: rgba(var(--bs-success-rgb, 25, 135, 84), 0.06);
+}
+
+/* Partial completion */
+.livingword-cal-partial {
+  border-color: var(--bs-warning, #ffc107);
+  background: rgba(var(--bs-warning-rgb, 255, 193, 7), 0.06);
+}
+
+/* Responsive: smaller cells on mobile */
+@media (max-width: 575.98px) {
+  .livingword-cal-cell {
+    min-height: 42px;
+    padding: 0.2rem;
+  }
+
+  .livingword-cal-date {
+    font-size: 0.7rem;
+  }
+
+  .livingword-cal-reading {
+    font-size: 0.55rem;
+  }
+
+  .livingword-cal-header {
+    font-size: 0.6rem;
+  }
 }
 
 /* ── Audio player refinements ── */

--- a/site/tmpl/cwmplanview/calendar.php
+++ b/site/tmpl/cwmplanview/calendar.php
@@ -12,7 +12,6 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
-use CWM\Component\Livingword\Site\Helper\CwmscriptureHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \CWM\Component\Livingword\Site\View\Cwmplanview\HtmlView $this */
@@ -28,6 +27,54 @@ $completedPassageCounts = $data->completedPassageCounts ?? [];
 /** @var \Joomla\CMS\Document\HtmlDocument $doc */
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('com_livingword.main', 'media/com_livingword/css/livingword.css');
+
+// Build month data: key = Y-m, value = array of weeks
+$months    = [];
+$monthKeys = [];
+$date      = clone $startDate;
+
+// Day-of-week names
+$dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+foreach ($readings as $i => $reading) {
+    $monthKey = $date->format('Y-m');
+
+    if (!isset($months[$monthKey])) {
+        $months[$monthKey] = [
+            'label' => $date->format('F Y'),
+            'days'  => [],
+            'firstDow' => (int) $date->format('w'), // 0=Sun, 6=Sat
+        ];
+        $monthKeys[] = $monthKey;
+    }
+
+    $months[$monthKey]['days'][] = [
+        'day'     => $i + 1,
+        'date'    => (int) $date->format('j'),
+        'dow'     => (int) $date->format('w'),
+        'reading' => $reading,
+        'current' => ($i + 1) === $data->currentDay,
+    ];
+
+    $date->modify('+1 day');
+}
+
+// Find the month containing the current day for initial display
+$currentMonthKey = '';
+
+foreach ($months as $key => $month) {
+    foreach ($month['days'] as $day) {
+        if ($day['current']) {
+            $currentMonthKey = $key;
+
+            break 2;
+        }
+    }
+}
+
+if (empty($currentMonthKey)) {
+    $currentMonthKey = $monthKeys[0] ?? '';
+}
 ?>
 <div class="com-livingword-planview-calendar">
     <?php echo $this->menu; ?>
@@ -55,72 +102,106 @@ $wa->registerAndUseStyle('com_livingword.main', 'media/com_livingword/css/living
     <?php if (empty($readings)) : ?>
         <div class="alert alert-info"><?php echo Text::_('COM_LIVINGWORD_NO_READINGS'); ?></div>
     <?php else : ?>
-        <?php
-        // Group readings by month
-        $months = [];
-        $date   = clone $startDate;
 
-        foreach ($readings as $i => $reading) {
-            $monthKey = $date->format('Y-m');
+        <?php // ── Month Navigation + Calendar ── ?>
+        <?php foreach ($months as $monthKey => $month) : ?>
+            <div class="livingword-calendar-month" data-month="<?php echo $monthKey; ?>"
+                 style="<?php echo $monthKey !== $currentMonthKey ? 'display:none;' : ''; ?>">
 
-            if (!isset($months[$monthKey])) {
-                $months[$monthKey] = [
-                    'label'    => $date->format('F Y'),
-                    'readings' => [],
-                ];
-            }
+                <?php // Month header with prev/next ?>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <button type="button" class="btn btn-sm btn-outline-secondary livingword-cal-prev"
+                            data-month="<?php echo $monthKey; ?>"
+                            aria-label="<?php echo Text::_('JPREVIOUS'); ?>">
+                        <span class="icon-chevron-left" aria-hidden="true"></span>
+                    </button>
+                    <h3 class="mb-0"><?php echo $month['label']; ?></h3>
+                    <button type="button" class="btn btn-sm btn-outline-secondary livingword-cal-next"
+                            data-month="<?php echo $monthKey; ?>"
+                            aria-label="<?php echo Text::_('JNEXT'); ?>">
+                        <span class="icon-chevron-right" aria-hidden="true"></span>
+                    </button>
+                </div>
 
-            $months[$monthKey]['readings'][] = [
-                'day'     => $i + 1,
-                'date'    => $date->format('j'),
-                'reading' => $reading,
-                'current' => ($i + 1) === $data->currentDay,
-            ];
+                <?php // Day-of-week headers ?>
+                <div class="livingword-cal-grid">
+                    <?php foreach ($dayNames as $dn) : ?>
+                        <div class="livingword-cal-header"><?php echo $dn; ?></div>
+                    <?php endforeach; ?>
 
-            $date->modify('+1 day');
-        }
-        ?>
+                    <?php // Blank cells before first day ?>
+                    <?php for ($blank = 0; $blank < $month['firstDow']; $blank++) : ?>
+                        <div class="livingword-cal-cell livingword-cal-empty"></div>
+                    <?php endfor; ?>
 
-        <?php foreach ($months as $month) : ?>
-            <h3 class="mb-2"><?php echo $month['label']; ?></h3>
-            <div class="row row-cols-4 row-cols-sm-5 row-cols-md-7 livingword-calendar-grid mb-4">
-                <?php foreach ($month['readings'] as $entry) : ?>
-                    <?php
-                    $isDayStarted   = isset($completedDays[$entry['day']]);
-                    $passageCount   = CwmprogressHelper::countPassages($entry['reading']->reading);
-                    $completedPC    = $completedPassageCounts[$entry['day']] ?? 0;
-                    $isFullComplete = $isDayStarted && $completedPC >= $passageCount;
-                    $isPartial      = $isDayStarted && $completedPC > 0 && $completedPC < $passageCount;
+                    <?php // Reading days ?>
+                    <?php foreach ($month['days'] as $entry) : ?>
+                        <?php
+                        $isDayStarted   = isset($completedDays[$entry['day']]);
+                        $passageCount   = CwmprogressHelper::countPassages($entry['reading']->reading);
+                        $completedPC    = $completedPassageCounts[$entry['day']] ?? 0;
+                        $isFullComplete = $isDayStarted && $completedPC >= $passageCount;
+                        $isPartial      = $isDayStarted && $completedPC > 0 && $completedPC < $passageCount;
 
-                    $cardClass = 'livingword-calendar-card';
+                        $cellClass = 'livingword-cal-cell';
 
-                    if ($entry['current']) {
-                        $cardClass .= ' livingword-calendar-current border-primary';
-                    } elseif ($isFullComplete) {
-                        $cardClass .= ' border-success';
-                    } elseif ($isPartial) {
-                        $cardClass .= ' border-warning';
-                    }
-                    ?>
-                    <div class="col">
-                        <div class="card <?php echo $cardClass; ?> h-100" data-progress-day="<?php echo $entry['day']; ?>">
-                            <div class="card-body p-1 small">
-                                <div class="d-flex justify-content-between align-items-center">
-                                    <strong><?php echo $entry['date']; ?></strong>
-                                    <?php if ($isFullComplete) : ?>
-                                        <span class="icon-checkmark text-success" aria-hidden="true"></span>
-                                    <?php elseif ($isPartial) : ?>
-                                        <span class="text-warning" style="font-size: 0.65em;"><?php echo $completedPC; ?>/<?php echo $passageCount; ?></span>
-                                    <?php endif; ?>
-                                </div>
-                                <div class="text-truncate" style="font-size: 0.7em;">
-                                    <?php echo htmlspecialchars($entry['reading']->reading, ENT_QUOTES, 'UTF-8'); ?>
-                                </div>
+                        if ($entry['current']) {
+                            $cellClass .= ' livingword-cal-today';
+                        } elseif ($isFullComplete) {
+                            $cellClass .= ' livingword-cal-complete';
+                        } elseif ($isPartial) {
+                            $cellClass .= ' livingword-cal-partial';
+                        }
+                        ?>
+                        <div class="<?php echo $cellClass; ?>" data-progress-day="<?php echo $entry['day']; ?>"
+                             title="<?php echo Text::sprintf('COM_LIVINGWORD_DAY_OF', $entry['day'], $data->totalDays) . ': ' . $this->escape($entry['reading']->reading); ?>">
+                            <div class="livingword-cal-date">
+                                <?php echo $entry['date']; ?>
+                                <?php if ($isFullComplete) : ?>
+                                    <span class="icon-checkmark text-success" aria-hidden="true"></span>
+                                <?php elseif ($isPartial) : ?>
+                                    <span class="text-warning" style="font-size: 0.6em;"><?php echo $completedPC; ?>/<?php echo $passageCount; ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="livingword-cal-reading">
+                                <?php echo htmlspecialchars($entry['reading']->reading, ENT_QUOTES, 'UTF-8'); ?>
                             </div>
                         </div>
-                    </div>
-                <?php endforeach; ?>
+                    <?php endforeach; ?>
+                </div>
             </div>
         <?php endforeach; ?>
+
     <?php endif; ?>
 </div>
+
+<?php if (!empty($readings)) : ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var months = <?php echo json_encode($monthKeys); ?>;
+    var currentIdx = months.indexOf('<?php echo $currentMonthKey; ?>');
+
+    function showMonth(idx) {
+        document.querySelectorAll('.livingword-calendar-month').forEach(function(el) {
+            el.style.display = 'none';
+        });
+        var target = document.querySelector('[data-month="' + months[idx] + '"]');
+        if (target) target.style.display = '';
+    }
+
+    document.querySelectorAll('.livingword-cal-prev').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var idx = months.indexOf(this.dataset.month);
+            if (idx > 0) { currentIdx = idx - 1; showMonth(currentIdx); }
+        });
+    });
+
+    document.querySelectorAll('.livingword-cal-next').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var idx = months.indexOf(this.dataset.month);
+            if (idx < months.length - 1) { currentIdx = idx + 1; showMonth(currentIdx); }
+        });
+    });
+});
+</script>
+<?php endif; ?>


### PR DESCRIPTION
## Before
- 4-column flowing grid, all months rendered at once
- No day-of-week alignment (March 25 = Wednesday but shown in column 1)
- Infinite scrolling on 365-day plans

## After
- **7-column CSS grid** matching Sun–Sat with day-of-week headers
- **Blank cells** before first day for proper weekly alignment
- **Month navigation** — one month at a time with prev/next buttons
- **Auto-navigates** to the month containing today's reading
- Color-coded cells: blue (today), green (complete), yellow (partial)
- Hover effects and tooltips with full reading reference
- Responsive: smaller cells on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)