### PR TITLE
Add reading notes/journal per daily reading

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -121,6 +121,19 @@ CREATE TABLE IF NOT EXISTS `#__livingword_group_members` (
   KEY `idx_group_id` (`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS `#__livingword_notes` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL COMMENT 'FK to #__users.id',
+  `plan_id` int UNSIGNED NOT NULL COMMENT 'FK to plans.id',
+  `day` int UNSIGNED NOT NULL COMMENT '1-based day number',
+  `note_text` text NOT NULL COMMENT 'User journal/reflection text',
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_user_plan_day` (`user_id`, `plan_id`, `day`),
+  KEY `idx_user_plan` (`user_id`, `plan_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
 -- LivingWord Seed Data (v5.2.0 schema)
 
 INSERT INTO `#__livingword_plans` (`id`, `alias`, `title`, `description`, `message`, `audio`, `testament`, `published`, `ordering`) VALUES

--- a/admin/sql/updates/mysql/5.2.0.sql
+++ b/admin/sql/updates/mysql/5.2.0.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `#__livingword_notes` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL COMMENT 'FK to #__users.id',
+  `plan_id` int UNSIGNED NOT NULL COMMENT 'FK to plans.id',
+  `day` int UNSIGNED NOT NULL COMMENT '1-based day number',
+  `note_text` text NOT NULL COMMENT 'User journal/reflection text',
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_user_plan_day` (`user_id`, `plan_id`, `day`),
+  KEY `idx_user_plan` (`user_id`, `plan_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/media/com_livingword/css/livingword.css
+++ b/media/com_livingword/css/livingword.css
@@ -149,6 +149,28 @@
   font-size: 1rem;
 }
 
+/* ── Journal card ── */
+.livingword-journal-card {
+  border: none;
+  border-left: 4px solid var(--bs-success, #198754);
+  background: var(--bs-light, #f8f9fa);
+  border-radius: 0 8px 8px 0;
+}
+
+.livingword-notes-textarea {
+  border: 1px solid var(--bs-border-color-translucent, rgba(0, 0, 0, 0.1));
+  border-radius: 6px;
+  resize: vertical;
+  min-height: 80px;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.livingword-notes-textarea:focus {
+  border-color: var(--bs-success, #198754);
+  box-shadow: 0 0 0 0.15rem rgba(25, 135, 84, 0.15);
+}
+
 /* ── Partner card ── */
 .livingword-partner-card {
   border: 1px solid var(--bs-border-color, #dee2e6);

--- a/media/com_livingword/js/livingword-notes.js
+++ b/media/com_livingword/js/livingword-notes.js
@@ -1,0 +1,63 @@
+/**
+ * @package    Livingword
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Auto-saving reading notes/journal with debounce.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+  'use strict';
+
+  var container = document.querySelector('[data-livingword-notes]');
+  if (!container) return;
+
+  var textarea = container.querySelector('.livingword-notes-textarea');
+  var status = container.querySelector('.livingword-notes-status');
+  var saveUrl = container.dataset.notesUrl;
+  var planId = container.dataset.planId;
+  var day = container.dataset.day;
+  var csrfToken = Joomla.getOptions('csrf.token');
+  var debounceTimer = null;
+  var saving = false;
+
+  function setStatus(text, cssClass) {
+    if (!status) return;
+    status.textContent = text;
+    status.className = 'livingword-notes-status small ' + (cssClass || 'text-muted');
+  }
+
+  function saveNote() {
+    if (saving) return;
+    saving = true;
+    setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_SAVING') || 'Saving...', 'text-muted');
+
+    var url = saveUrl
+      + '&plan_id=' + encodeURIComponent(planId)
+      + '&day=' + encodeURIComponent(day)
+      + '&note_text=' + encodeURIComponent(textarea.value)
+      + '&' + csrfToken + '=1';
+
+    fetch(url, { method: 'GET', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      .then(function (response) { return response.json(); })
+      .then(function (json) {
+        saving = false;
+        if (json.success) {
+          setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_SAVED') || 'Saved', 'text-success');
+        } else {
+          setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_ERROR') || 'Error', 'text-danger');
+        }
+      })
+      .catch(function () {
+        saving = false;
+        setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_ERROR') || 'Error', 'text-danger');
+      });
+  }
+
+  if (textarea) {
+    textarea.addEventListener('input', function () {
+      setStatus('', '');
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(saveNote, 800);
+    });
+  }
+});

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -130,6 +130,14 @@ COM_LIVINGWORD_ROLE_ADMIN="Group Admin"
 COM_LIVINGWORD_ROLE_MEMBER="Member"
 COM_LIVINGWORD_LOGIN_REQUIRED="Please log in to join a group."
 
+; Journal / Notes
+COM_LIVINGWORD_MY_JOURNAL="My Journal"
+COM_LIVINGWORD_NOTES_PLACEHOLDER="Write your reflections on today's reading..."
+COM_LIVINGWORD_NOTES_SAVED="Saved"
+COM_LIVINGWORD_NOTES_SAVING="Saving..."
+COM_LIVINGWORD_NOTES_ERROR="Could not save. Please try again."
+COM_LIVINGWORD_NOTES_INDICATOR="Has notes"
+
 ; Audio settings
 COM_LIVINGWORD_AUDIO_VERSION="Audio Bible Version"
 COM_LIVINGWORD_AUDIO_VERSION_DESC="Optional: preferred BibleBrain audio fileset code. Leave empty to use the plan default."

--- a/site/src/Controller/CwmnotesController.php
+++ b/site/src/Controller/CwmnotesController.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Site\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Livingword\Site\Helper\CwmnotesHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Response\JsonResponse;
+use Joomla\CMS\Session\Session;
+
+/**
+ * AJAX controller for reading notes/journal.
+ *
+ * @since  5.2.0
+ */
+class CwmnotesController extends BaseController
+{
+    /**
+     * Save a note for a specific reading day. Returns JSON.
+     *
+     * @return  void
+     *
+     * @since   5.2.0
+     */
+    public function save(): void
+    {
+        $app = $this->app;
+        $app->setHeader('Content-Type', 'application/json; charset=utf-8');
+
+        if (!Session::checkToken('get')) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Invalid session token', true);
+            $app->close();
+        }
+
+        $userId = (int) $app->getIdentity()->id;
+
+        if ($userId === 0) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Login required', true);
+            $app->close();
+        }
+
+        $planId = $this->input->getInt('plan_id', 0);
+        $day    = $this->input->getInt('day', 0);
+        $text   = $this->input->getString('note_text', '');
+
+        if ($planId <= 0 || $day <= 0) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Invalid plan or day', true);
+            $app->close();
+        }
+
+        $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+
+        CwmnotesHelper::saveNote($db, $userId, $planId, $day, $text);
+
+        $app->sendHeaders();
+        echo new JsonResponse([
+            'saved'   => true,
+            'plan_id' => $planId,
+            'day'     => $day,
+        ]);
+        $app->close();
+    }
+
+    /**
+     * Load a note for a specific reading day. Returns JSON.
+     *
+     * @return  void
+     *
+     * @since   5.2.0
+     */
+    public function load(): void
+    {
+        $app = $this->app;
+        $app->setHeader('Content-Type', 'application/json; charset=utf-8');
+
+        if (!Session::checkToken('get')) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Invalid session token', true);
+            $app->close();
+        }
+
+        $userId = (int) $app->getIdentity()->id;
+
+        if ($userId === 0) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Login required', true);
+            $app->close();
+        }
+
+        $planId = $this->input->getInt('plan_id', 0);
+        $day    = $this->input->getInt('day', 0);
+
+        if ($planId <= 0 || $day <= 0) {
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Invalid plan or day', true);
+            $app->close();
+        }
+
+        $db   = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $note = CwmnotesHelper::getNote($db, $userId, $planId, $day);
+
+        $app->sendHeaders();
+        echo new JsonResponse([
+            'note_text' => $note ?? '',
+            'plan_id'   => $planId,
+            'day'       => $day,
+        ]);
+        $app->close();
+    }
+}

--- a/site/src/Helper/CwmnotesHelper.php
+++ b/site/src/Helper/CwmnotesHelper.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Site\Helper;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Helper for reading notes/journal entries.
+ *
+ * One note per user per plan per day, stored in #__livingword_notes.
+ *
+ * @since  5.2.0
+ */
+class CwmnotesHelper
+{
+    /**
+     * Get a single note for a specific day.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  User ID
+     * @param   int                $planId  Plan ID
+     * @param   int                $day     Day number (1-based)
+     *
+     * @return  ?string  Note text or null if none exists
+     *
+     * @since   5.2.0
+     */
+    public static function getNote(DatabaseInterface $db, int $userId, int $planId, int $day): ?string
+    {
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('note_text'))
+            ->from($db->quoteName('#__livingword_notes'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->where($db->quoteName('day') . ' = ' . $day);
+
+        $db->setQuery($query);
+
+        $result = $db->loadResult();
+
+        return $result !== null ? (string) $result : null;
+    }
+
+    /**
+     * Save (upsert) a note. Deletes the row if text is empty.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  User ID
+     * @param   int                $planId  Plan ID
+     * @param   int                $day     Day number (1-based)
+     * @param   string             $text    Note text
+     *
+     * @return  bool  True on success
+     *
+     * @since   5.2.0
+     */
+    public static function saveNote(DatabaseInterface $db, int $userId, int $planId, int $day, string $text): bool
+    {
+        $text = trim($text);
+
+        if ($text === '') {
+            $query = $db->getQuery(true)
+                ->delete($db->quoteName('#__livingword_notes'))
+                ->where($db->quoteName('user_id') . ' = ' . $userId)
+                ->where($db->quoteName('plan_id') . ' = ' . $planId)
+                ->where($db->quoteName('day') . ' = ' . $day);
+
+            $db->setQuery($query);
+            $db->execute();
+
+            return true;
+        }
+
+        $now = (new \DateTime())->format('Y-m-d H:i:s');
+
+        $query = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__livingword_notes'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->where($db->quoteName('day') . ' = ' . $day);
+
+        $db->setQuery($query);
+        $exists = (int) $db->loadResult() > 0;
+
+        if ($exists) {
+            $query = $db->getQuery(true)
+                ->update($db->quoteName('#__livingword_notes'))
+                ->set($db->quoteName('note_text') . ' = ' . $db->quote($text))
+                ->set($db->quoteName('modified') . ' = ' . $db->quote($now))
+                ->where($db->quoteName('user_id') . ' = ' . $userId)
+                ->where($db->quoteName('plan_id') . ' = ' . $planId)
+                ->where($db->quoteName('day') . ' = ' . $day);
+        } else {
+            $query = $db->getQuery(true)
+                ->insert($db->quoteName('#__livingword_notes'))
+                ->columns([
+                    $db->quoteName('user_id'),
+                    $db->quoteName('plan_id'),
+                    $db->quoteName('day'),
+                    $db->quoteName('note_text'),
+                    $db->quoteName('created'),
+                    $db->quoteName('modified'),
+                ])
+                ->values(implode(',', [
+                    $userId,
+                    $planId,
+                    $day,
+                    $db->quote($text),
+                    $db->quote($now),
+                    $db->quote($now),
+                ]));
+        }
+
+        $db->setQuery($query);
+        $db->execute();
+
+        return true;
+    }
+
+    /**
+     * Get all notes for a user's plan as an associative array [day => note_text].
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  User ID
+     * @param   int                $planId  Plan ID
+     *
+     * @return  array<int, string>  Associative array keyed by day number
+     *
+     * @since   5.2.0
+     */
+    public static function getNotesForPlan(DatabaseInterface $db, int $userId, int $planId): array
+    {
+        $query = $db->getQuery(true)
+            ->select([$db->quoteName('day'), $db->quoteName('note_text')])
+            ->from($db->quoteName('#__livingword_notes'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->order($db->quoteName('day') . ' ASC');
+
+        $db->setQuery($query);
+
+        $rows  = $db->loadObjectList();
+        $notes = [];
+
+        foreach ($rows as $row) {
+            $notes[(int) $row->day] = $row->note_text;
+        }
+
+        return $notes;
+    }
+
+    /**
+     * Get days that have notes (for indicator display).
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  User ID
+     * @param   int                $planId  Plan ID
+     *
+     * @return  array<int>  Array of day numbers that have notes
+     *
+     * @since   5.2.0
+     */
+    public static function getNoteDays(DatabaseInterface $db, int $userId, int $planId): array
+    {
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('day'))
+            ->from($db->quoteName('#__livingword_notes'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId);
+
+        $db->setQuery($query);
+
+        return array_map('intval', $db->loadColumn());
+    }
+}

--- a/site/src/Model/CwmhomeModel.php
+++ b/site/src/Model/CwmhomeModel.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmnotesHelper;
 use CWM\Component\Livingword\Site\Helper\CwmpartnerHelper;
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
@@ -78,9 +79,11 @@ class CwmhomeModel extends BaseDatabaseModel
         $progressPercent = ($totalDays > 0) ? round(($completedCount / $totalDays) * 100) : 0;
 
         $partnerProgress = null;
+        $todayNote       = '';
 
         if ($userId > 0) {
             $partnerProgress = CwmpartnerHelper::getPartnerProgress($db, $userId);
+            $todayNote       = CwmnotesHelper::getNote($db, $userId, $planId, $currentDay) ?? '';
         }
 
         return (object) [
@@ -97,6 +100,7 @@ class CwmhomeModel extends BaseDatabaseModel
             'completedPassages' => $completedPassages,
             'partnerProgress'   => $partnerProgress,
             'durationType'      => $planInfo->duration_type ?? 'annual',
+            'todayNote'         => $todayNote,
         ];
     }
 }

--- a/site/src/Model/CwmplanviewModel.php
+++ b/site/src/Model/CwmplanviewModel.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Livingword\Site\Helper\CwmnotesHelper;
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
@@ -56,10 +57,12 @@ class CwmplanviewModel extends BaseDatabaseModel
 
         $completedDays          = [];
         $completedPassageCounts = [];
+        $noteDays               = [];
 
         if ($userId > 0) {
             $completedDays          = CwmprogressHelper::getCompletedDays($db, $userId, $planId);
             $completedPassageCounts = CwmprogressHelper::getCompletedPassageCounts($db, $userId, $planId);
+            $noteDays               = CwmnotesHelper::getNoteDays($db, $userId, $planId);
         }
 
         $completedCount  = \count($completedDays);
@@ -75,6 +78,7 @@ class CwmplanviewModel extends BaseDatabaseModel
             'completedCount'         => $completedCount,
             'progressPercent'        => $progressPercent,
             'completedPassageCounts' => $completedPassageCounts,
+            'noteDays'               => $noteDays,
         ];
     }
 }

--- a/site/tmpl/cwmhome/default.php
+++ b/site/tmpl/cwmhome/default.php
@@ -42,8 +42,11 @@ $wa->registerAndUseStyle('com_livingword.main', 'media/com_livingword/css/living
 
 if ($isLoggedIn && $reading) {
     $wa->registerAndUseScript('com_livingword.progress', 'media/com_livingword/js/livingword-progress.js', [], ['defer' => true]);
+    $wa->registerAndUseScript('com_livingword.notes', 'media/com_livingword/js/livingword-notes.js', [], ['defer' => true]);
     $doc->addScriptOptions('csrf.token', Session::getFormToken());
 }
+
+$notesUrl = Route::_('index.php?option=com_livingword&task=cwmnotes.save&format=json', false);
 
 // Audio availability check
 $audioEnabled = (int) \Joomla\CMS\Component\ComponentHelper::getParams('com_livingword')->get('config_show_audio', 1);
@@ -226,6 +229,29 @@ if ($showAudio && $reading) {
                     </h5>
                     <div class="livingword-devotional">
                         <?php echo $reading->descrip; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <?php // ── Journal / Notes ── ?>
+        <?php if ($isLoggedIn) : ?>
+            <div class="card livingword-journal-card mb-4"
+                 data-livingword-notes
+                 data-notes-url="<?php echo $this->escape($notesUrl); ?>"
+                 data-plan-id="<?php echo (int) ($plan->id ?? 0); ?>"
+                 data-day="<?php echo (int) $data->currentDay; ?>">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        <span class="icon-pencil-2" aria-hidden="true"></span>
+                        <?php echo Text::_('COM_LIVINGWORD_MY_JOURNAL'); ?>
+                    </h5>
+                    <textarea class="form-control livingword-notes-textarea"
+                              rows="4"
+                              placeholder="<?php echo Text::_('COM_LIVINGWORD_NOTES_PLACEHOLDER'); ?>"
+                    ><?php echo $this->escape($data->todayNote ?? ''); ?></textarea>
+                    <div class="d-flex justify-content-end mt-1">
+                        <span class="livingword-notes-status small text-muted"></span>
                     </div>
                 </div>
             </div>

--- a/site/tmpl/cwmplanview/default.php
+++ b/site/tmpl/cwmplanview/default.php
@@ -23,6 +23,7 @@ $plan                   = $data->planInfo;
 $user                   = $data->userData;
 $completedDays          = array_flip($data->completedDays ?? []);
 $completedPassageCounts = $data->completedPassageCounts ?? [];
+$noteDays               = array_flip($data->noteDays ?? []);
 
 // Calculate the date for each reading day based on user start date
 $startDate = $user->start_date ?? '';
@@ -187,6 +188,11 @@ $wa->registerAndUseStyle('com_livingword.main', 'media/com_livingword/css/living
                                             <td class="livingword-day-cell"><?php echo $r['dayNum']; ?></td>
                                             <td>
                                                 <?php echo CwmscriptureHelper::buildReadingLink($r['reading']->reading, $user->bible_version); ?>
+                                                <?php if (isset($noteDays[$r['dayNum']])) : ?>
+                                                    <span class="icon-pencil-2 text-success ms-1" style="font-size: 0.75em;"
+                                                          aria-label="<?php echo Text::_('COM_LIVINGWORD_NOTES_INDICATOR'); ?>"
+                                                          title="<?php echo Text::_('COM_LIVINGWORD_MY_JOURNAL'); ?>"></span>
+                                                <?php endif; ?>
                                                 <?php if (!empty(trim($r['reading']->descrip ?? ''))) : ?>
                                                     <div class="text-muted small mt-1" style="font-style: italic;">
                                                         <?php echo htmlspecialchars(mb_strimwidth(strip_tags($r['reading']->descrip), 0, 120, '...'), ENT_QUOTES, 'UTF-8'); ?>


### PR DESCRIPTION
## Summary
- New `#__livingword_notes` table for personal reading reflections (one per user/plan/day)
- Auto-saving journal textarea on the home view with 800ms debounce
- AJAX controller (`CwmnotesController`) for save/load operations
- Note indicator (pencil icon) on the plan view for days with journal entries
- Green-accented journal card styled consistently with the devotional card
- Empty notes auto-delete the row (no empty records stored)

Fixes #58

## Test plan
- [ ] Navigate to home view — verify journal card appears below devotional
- [ ] Type in the journal textarea — verify "Saving..." then "Saved" status
- [ ] Reload page — verify note text persists
- [ ] Clear the textarea — verify note is deleted (row removed)
- [ ] Check plan view — verify pencil icon appears on days with notes
- [ ] Log out — verify journal card is hidden for guests

🤖 Generated with [Claude Code](https://claude.com/claude-code)