### PR TITLE
Add one-click reading completion from daily email

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS `#__livingword_users` (
   `audio_version` varchar(20) NOT NULL DEFAULT '' COMMENT 'Preferred audio Bible fileset code',
   `email` tinyint NOT NULL DEFAULT 0 COMMENT 'Receive daily reading email (0/1)',
   `unsubscribe_token` varchar(64) DEFAULT NULL COMMENT 'One-click email unsubscribe token',
+  `action_token` varchar(64) DEFAULT NULL COMMENT 'Token for email-based reading completion',
   `plan_view` tinyint NOT NULL DEFAULT 0 COMMENT '0=default, 1=list, 2=calendar',
   `start_date` date DEFAULT NULL COMMENT 'Reading plan start date',
   `date_offset` int NOT NULL DEFAULT 0 COMMENT 'Day offset adjustment',

--- a/admin/sql/updates/mysql/5.3.0.sql
+++ b/admin/sql/updates/mysql/5.3.0.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `#__livingword_users`
+  ADD COLUMN `action_token` varchar(64) DEFAULT NULL COMMENT 'Token for email-based reading completion' AFTER `unsubscribe_token`,
+  ADD KEY `idx_action_token` (`action_token`);

--- a/plg_task_livingword/src/Extension/Livingword.php
+++ b/plg_task_livingword/src/Extension/Livingword.php
@@ -124,12 +124,19 @@ class Livingword extends CMSPlugin implements SubscriberInterface
                 continue;
             }
 
-            // Ensure unsubscribe token exists
-            $token = CwmuserHelper::ensureUnsubscribeToken($db, (int) $sub->user_id);
+            // Ensure tokens exist
+            $token          = CwmuserHelper::ensureUnsubscribeToken($db, (int) $sub->user_id);
             $unsubscribeUrl = CwmuserHelper::getUnsubscribeUrl($token);
+            $actionToken    = CwmuserHelper::ensureActionToken($db, (int) $sub->user_id);
+            $completeUrl    = CwmuserHelper::getCompleteReadingUrl($actionToken);
 
             $body = '<p>Today\'s reading (Day ' . $currentDay . '):</p>'
                   . CwmscriptureHelper::buildEmailContent($reading->reading, $version)
+                  . '<p style="margin:20px 0;text-align:center;">'
+                  . '<a href="' . htmlspecialchars($completeUrl, ENT_QUOTES, 'UTF-8') . '" '
+                  . 'style="display:inline-block;padding:10px 24px;background:#198754;color:#fff;'
+                  . 'text-decoration:none;border-radius:6px;font-weight:600;">'
+                  . 'Mark as Read</a></p>'
                   . '<p>From ' . htmlspecialchars($siteName, ENT_QUOTES, 'UTF-8') . '</p>'
                   . '<hr style="margin-top:20px;border:none;border-top:1px solid #ccc;">'
                   . '<p style="font-size:0.85em;color:#666;">'

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -66,6 +66,12 @@ COM_LIVINGWORD_OF_DAYS="of %d"
 COM_LIVINGWORD_SKIP_TO_TODAY="Skip to Today"
 COM_LIVINGWORD_RESTART_PLAN="Restart Plan"
 
+; Email completion
+COM_LIVINGWORD_COMPLETE_SUCCESS="Your reading for today has been marked complete!"
+COM_LIVINGWORD_COMPLETE_DAY_INFO="Day %1$d: %2$s"
+COM_LIVINGWORD_COMPLETE_INVALID="This completion link is invalid."
+COM_LIVINGWORD_COMPLETE_VISIT_SITE="Continue to your reading plan"
+
 ; Unsubscribe
 COM_LIVINGWORD_UNSUBSCRIBE_SUCCESS="You have been successfully unsubscribed from daily reading emails."
 COM_LIVINGWORD_UNSUBSCRIBE_INVALID="This unsubscribe link is invalid or has already been used."

--- a/site/src/Controller/CwmcompleteController.php
+++ b/site/src/Controller/CwmcompleteController.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Site\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
+use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
+use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Router\Route;
+
+/**
+ * Public reading completion controller — no login required.
+ *
+ * Handles one-click reading completion via action token from daily emails.
+ *
+ * @since  5.3.0
+ */
+class CwmcompleteController extends BaseController
+{
+    /**
+     * Mark today's reading as complete using an action token.
+     *
+     * URL: index.php?option=com_livingword&task=cwmcomplete.complete&token=XXX
+     *
+     * @return  void
+     *
+     * @since   5.3.0
+     */
+    public function complete(): void
+    {
+        $token = $this->input->getString('token', '');
+        $db    = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $app   = $this->app;
+
+        $userData = CwmuserHelper::getUserByActionToken($db, $token);
+
+        if (!$userData) {
+            $app->setUserState('com_livingword.complete.success', false);
+            $this->setRedirect(Route::_('index.php?option=com_livingword&view=cwmcomplete', false));
+
+            return;
+        }
+
+        $userId = (int) $userData->user_id;
+        $planId = (int) $userData->plan_id;
+
+        $planInfo  = CwmreadingHelper::getPlanById($db, $planId);
+        $totalDays = CwmreadingHelper::getPlanTotalDays($db, $planId);
+
+        $currentDay = CwmreadingHelper::getReadingDayForPlan(
+            $planInfo,
+            $userData->start_date ?? '',
+            (int) $userData->date_offset,
+            $totalDays ?: 365,
+            $db,
+            $userId
+        );
+
+        $reading = CwmreadingHelper::getReadingForDay($db, $planId, $currentDay);
+
+        if (!$reading) {
+            $app->setUserState('com_livingword.complete.success', false);
+            $this->setRedirect(Route::_('index.php?option=com_livingword&view=cwmcomplete', false));
+
+            return;
+        }
+
+        $passageCount = CwmprogressHelper::countPassages($reading->reading);
+
+        // Mark all passages as complete (idempotent)
+        for ($i = 0; $i < $passageCount; $i++) {
+            if (!CwmprogressHelper::isPassageCompleted($db, $userId, $planId, $currentDay, $i)) {
+                CwmprogressHelper::markPassageComplete($db, $userId, $planId, $currentDay, $i);
+            }
+        }
+
+        // Update streak
+        CwmprogressHelper::updateStreak($db, $userId);
+
+        $app->setUserState('com_livingword.complete.success', true);
+        $app->setUserState('com_livingword.complete.day', $currentDay);
+        $app->setUserState('com_livingword.complete.reading', $reading->reading);
+
+        $this->setRedirect(Route::_('index.php?option=com_livingword&view=cwmcomplete', false));
+    }
+}

--- a/site/src/Helper/CwmuserHelper.php
+++ b/site/src/Helper/CwmuserHelper.php
@@ -224,6 +224,83 @@ class CwmuserHelper
     }
 
     /**
+     * Ensure a user has an action token for email-based completion.
+     *
+     * @param   DatabaseInterface  $db      Database instance
+     * @param   int                $userId  Joomla user ID
+     *
+     * @return  string  The action token
+     *
+     * @since   5.3.0
+     */
+    public static function ensureActionToken(DatabaseInterface $db, int $userId): string
+    {
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('action_token'))
+            ->from($db->quoteName('#__livingword_users'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId);
+
+        $db->setQuery($query);
+        $token = $db->loadResult();
+
+        if (!empty($token)) {
+            return $token;
+        }
+
+        $token = bin2hex(random_bytes(32));
+
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__livingword_users'))
+            ->set($db->quoteName('action_token') . ' = ' . $db->quote($token))
+            ->where($db->quoteName('user_id') . ' = ' . $userId);
+
+        $db->setQuery($query);
+        $db->execute();
+
+        return $token;
+    }
+
+    /**
+     * Build the completion URL for a given action token.
+     *
+     * @param   string  $token  The action token
+     *
+     * @return  string  Absolute URL
+     *
+     * @since   5.3.0
+     */
+    public static function getCompleteReadingUrl(string $token): string
+    {
+        return Uri::root() . 'index.php?option=com_livingword&task=cwmcomplete.complete&token=' . urlencode($token);
+    }
+
+    /**
+     * Look up a user by their action token.
+     *
+     * @param   DatabaseInterface  $db     Database instance
+     * @param   string             $token  The action token
+     *
+     * @return  ?object  User row or null if not found
+     *
+     * @since   5.3.0
+     */
+    public static function getUserByActionToken(DatabaseInterface $db, string $token): ?object
+    {
+        if (empty($token) || \strlen($token) !== 64) {
+            return null;
+        }
+
+        $query = $db->getQuery(true)
+            ->select('*')
+            ->from($db->quoteName('#__livingword_users'))
+            ->where($db->quoteName('action_token') . ' = ' . $db->quote($token));
+
+        $db->setQuery($query);
+
+        return $db->loadObject() ?: null;
+    }
+
+    /**
      * Resolve a plan alias to its ID.
      *
      * @param   DatabaseInterface  $db     Database instance

--- a/site/src/View/Cwmcomplete/HtmlView.php
+++ b/site/src/View/Cwmcomplete/HtmlView.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Site\View\Cwmcomplete;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+
+/**
+ * Reading completion confirmation view.
+ *
+ * @since  5.3.0
+ */
+class HtmlView extends BaseHtmlView
+{
+    /** @var bool @since 5.3.0 */
+    protected bool $success = false;
+
+    /** @var int @since 5.3.0 */
+    protected int $day = 0;
+
+    /** @var string @since 5.3.0 */
+    protected string $reading = '';
+
+    /**
+     * @param   string  $tpl  Template name.
+     *
+     * @return  void
+     *
+     * @throws  \Exception
+     * @since   5.3.0
+     */
+    #[\Override]
+    public function display($tpl = null): void
+    {
+        $app           = Factory::getApplication();
+        $this->success = (bool) $app->getUserState('com_livingword.complete.success', false);
+        $this->day     = (int) $app->getUserState('com_livingword.complete.day', 0);
+        $this->reading = (string) $app->getUserState('com_livingword.complete.reading', '');
+
+        $app->setUserState('com_livingword.complete.success', null);
+        $app->setUserState('com_livingword.complete.day', null);
+        $app->setUserState('com_livingword.complete.reading', null);
+
+        parent::display($tpl);
+    }
+}

--- a/site/tmpl/cwmcomplete/default.php
+++ b/site/tmpl/cwmcomplete/default.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
+/** @var \CWM\Component\Livingword\Site\View\Cwmcomplete\HtmlView $this */
+
+$wa = $this->getDocument()->getWebAssetManager();
+$wa->registerAndUseStyle('com_livingword.main', 'media/com_livingword/css/livingword.css');
+?>
+<div class="com-livingword-complete">
+    <?php if ($this->success) : ?>
+        <div class="alert alert-success">
+            <h4 class="alert-heading">
+                <span class="icon-checkmark" aria-hidden="true"></span>
+                <?php echo Text::_('COM_LIVINGWORD_COMPLETE_SUCCESS'); ?>
+            </h4>
+            <?php if ($this->day > 0) : ?>
+                <p class="mb-0">
+                    <?php echo Text::sprintf('COM_LIVINGWORD_COMPLETE_DAY_INFO', $this->day, $this->escape($this->reading)); ?>
+                </p>
+            <?php endif; ?>
+        </div>
+        <p>
+            <a href="<?php echo Route::_('index.php?option=com_livingword&view=cwmhome'); ?>" class="btn btn-primary">
+                <?php echo Text::_('COM_LIVINGWORD_COMPLETE_VISIT_SITE'); ?>
+            </a>
+        </p>
+    <?php else : ?>
+        <div class="alert alert-warning">
+            <h4><?php echo Text::_('COM_LIVINGWORD_COMPLETE_INVALID'); ?></h4>
+        </div>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
## Summary
- New `action_token` column on `#__livingword_users` for secure email-based actions
- Green "Mark as Read" button in daily email notifications
- `CwmcompleteController` handles token validation and marks all passages complete
- Confirmation page shows success/error state with link to continue reading
- Idempotent: re-clicking already-completed readings silently succeeds
- Streak tracking updated after email-based completion

Fixes #57

## Test plan
- [ ] Verify `action_token` column added via migration
- [ ] Send a test daily email — verify green "Mark as Read" button present
- [ ] Click the button — verify confirmation page shows success
- [ ] Check the home view — verify today's reading is marked complete
- [ ] Click the button again — verify it succeeds silently (idempotent)
- [ ] Test with an invalid/empty token — verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)