### PR TITLE
Enhance study/devotional text display alongside scripture

### DIFF
--- a/media/com_livingword/css/livingword.css
+++ b/media/com_livingword/css/livingword.css
@@ -136,6 +136,51 @@
 }
 
 /* ── Devotional card ── */
+/* ── Study/Devotional card ── */
+.livingword-study-card {
+  border: none;
+  border-left: 4px solid var(--bs-primary, #0d6efd);
+  background: var(--bs-light, #f8f9fa);
+  border-radius: 0 8px 8px 0;
+}
+
+.livingword-study-content {
+  font-family: Georgia, 'Times New Roman', serif;
+  line-height: 1.8;
+  font-size: 1.05rem;
+}
+
+.livingword-study-collapsed {
+  max-height: 12em;
+  overflow: hidden;
+  position: relative;
+}
+
+.livingword-study-collapsed::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 4em;
+  background: linear-gradient(transparent, var(--bs-light, #f8f9fa));
+  pointer-events: none;
+}
+
+.livingword-study-toggle {
+  font-size: 0.85rem;
+  text-decoration: none;
+}
+
+.livingword-study-inline {
+  padding: 0.75rem;
+  background: var(--bs-light, #f8f9fa);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+/* Deprecated — kept for template override compat */
 .livingword-devotional-card {
   border: none;
   border-left: 4px solid var(--bs-primary, #0d6efd);

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -32,8 +32,11 @@ COM_LIVINGWORD_SETTINGS_READING="Reading Preferences"
 COM_LIVINGWORD_SETTINGS_EMAIL="Email Notifications"
 COM_LIVINGWORD_AUDIO_VERSION_DEFAULT="Use Plan Default"
 
-; Devotional
+; Study / Devotional
 COM_LIVINGWORD_TODAYS_REFLECTION="Today's Reflection"
+COM_LIVINGWORD_STUDY_NOTES="Study Notes"
+COM_LIVINGWORD_READ_MORE="Read more"
+COM_LIVINGWORD_READ_LESS="Read less"
 
 ; Reading completion
 COM_LIVINGWORD_MARK_READ="Mark as Read"

--- a/site/tmpl/cwmhome/default.php
+++ b/site/tmpl/cwmhome/default.php
@@ -203,6 +203,37 @@ if ($showAudio && $reading) {
             </div>
         </div>
 
+        <?php // ── Study Notes / Devotional ── ?>
+        <?php
+        $descripText = trim($reading->descrip ?? '');
+        $hasStudyText = !empty($descripText);
+        $isLongText = $hasStudyText && str_word_count(strip_tags($descripText)) > 150;
+        ?>
+        <?php if ($hasStudyText) : ?>
+            <div class="card livingword-study-card mb-4">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        <span class="icon-book" aria-hidden="true"></span>
+                        <?php echo Text::_('COM_LIVINGWORD_STUDY_NOTES'); ?>
+                    </h5>
+                    <?php if ($isLongText) : ?>
+                        <div class="livingword-study-content livingword-study-collapsed" id="studyContent">
+                            <?php echo $reading->descrip; ?>
+                        </div>
+                        <button type="button" class="btn btn-sm btn-link p-0 mt-2 livingword-study-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#studyContentFull"
+                                onclick="this.closest('.card-body').querySelector('.livingword-study-content').classList.toggle('livingword-study-collapsed'); this.textContent = this.textContent.trim() === '<?php echo Text::_('COM_LIVINGWORD_READ_MORE'); ?>' ? '<?php echo Text::_('COM_LIVINGWORD_READ_LESS'); ?>' : '<?php echo Text::_('COM_LIVINGWORD_READ_MORE'); ?>';">
+                            <?php echo Text::_('COM_LIVINGWORD_READ_MORE'); ?>
+                        </button>
+                    <?php else : ?>
+                        <div class="livingword-study-content">
+                            <?php echo $reading->descrip; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endif; ?>
+
         <?php // ── Audio Player ── ?>
         <?php if ($showAudio) : ?>
             <div class="livingword-audio-section mb-4"
@@ -216,21 +247,6 @@ if ($showAudio && $reading) {
                 </button>
                 <audio preload="none"></audio>
                 <span class="livingword-audio-status d-none"></span>
-            </div>
-        <?php endif; ?>
-
-        <?php // ── Devotional / Reflection ── ?>
-        <?php if (!empty(trim($reading->descrip ?? ''))) : ?>
-            <div class="card livingword-devotional-card mb-4">
-                <div class="card-body">
-                    <h5 class="card-title">
-                        <span class="icon-quote" aria-hidden="true"></span>
-                        <?php echo Text::_('COM_LIVINGWORD_TODAYS_REFLECTION'); ?>
-                    </h5>
-                    <div class="livingword-devotional">
-                        <?php echo $reading->descrip; ?>
-                    </div>
-                </div>
             </div>
         <?php endif; ?>
 
@@ -256,7 +272,6 @@ if ($showAudio && $reading) {
                 </div>
             </div>
         <?php endif; ?>
-
     <?php else : ?>
         <div class="alert alert-info"><?php echo Text::_('COM_LIVINGWORD_NO_READING_TODAY'); ?></div>
     <?php endif; ?>

--- a/site/tmpl/cwmplanview/default.php
+++ b/site/tmpl/cwmplanview/default.php
@@ -193,9 +193,21 @@ $wa->registerAndUseStyle('com_livingword.main', 'media/com_livingword/css/living
                                                           aria-label="<?php echo Text::_('COM_LIVINGWORD_NOTES_INDICATOR'); ?>"
                                                           title="<?php echo Text::_('COM_LIVINGWORD_MY_JOURNAL'); ?>"></span>
                                                 <?php endif; ?>
-                                                <?php if (!empty(trim($r['reading']->descrip ?? ''))) : ?>
-                                                    <div class="text-muted small mt-1" style="font-style: italic;">
-                                                        <?php echo htmlspecialchars(mb_strimwidth(strip_tags($r['reading']->descrip), 0, 120, '...'), ENT_QUOTES, 'UTF-8'); ?>
+                                                <?php $descripContent = trim($r['reading']->descrip ?? ''); ?>
+                                                <?php if (!empty($descripContent)) : ?>
+                                                    <?php $collapseStudyId = 'study-day-' . $r['dayNum']; ?>
+                                                    <button class="btn btn-sm btn-link p-0 ms-1 livingword-study-toggle"
+                                                            type="button"
+                                                            data-bs-toggle="collapse"
+                                                            data-bs-target="#<?php echo $collapseStudyId; ?>"
+                                                            aria-expanded="false">
+                                                        <span class="icon-book" aria-hidden="true" style="font-size: 0.8em;"></span>
+                                                        <?php echo Text::_('COM_LIVINGWORD_STUDY_NOTES'); ?>
+                                                    </button>
+                                                    <div class="collapse mt-2" id="<?php echo $collapseStudyId; ?>">
+                                                        <div class="livingword-study-inline">
+                                                            <?php echo $r['reading']->descrip; ?>
+                                                        </div>
                                                     </div>
                                                 <?php endif; ?>
                                             </td>


### PR DESCRIPTION
## Summary
- Replaces truncated 120-char italic preview with a prominent "Study Notes" card on home view
- Study card positioned between the reading card and audio player for natural reading flow
- Long devotional content (150+ words) gets a gradient fade with "Read more/less" toggle
- Plan view: each day with study text gets an expandable "Study Notes" collapse toggle
- Full HTML content displayed when expanded (no more truncation)
- New CSS classes: `.livingword-study-card`, `.livingword-study-content`, `.livingword-study-collapsed`
- Old `.livingword-devotional-card` styles kept for template override compatibility

Fixes #59

## Test plan
- [ ] Check home view with a plan that has study text — verify Study Notes card appears
- [ ] Test with long devotional content (150+ words) — verify gradient fade + "Read more" button
- [ ] Click "Read more" — verify content expands, button changes to "Read less"
- [ ] Check home view with a plan that has NO study text — verify no card renders
- [ ] Check plan view — verify "Study Notes" toggle appears on days with content
- [ ] Click the toggle — verify inline content expands/collapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)