### PR TITLE
Redesign home page with hero welcome and dashboard stats

### DIFF
--- a/media/com_livingword/css/livingword.css
+++ b/media/com_livingword/css/livingword.css
@@ -15,6 +15,111 @@
   margin: 0 auto;
 }
 
+/* ── Hero / Welcome ── */
+.livingword-hero {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(var(--bs-primary-rgb, 13, 110, 253), 0.06), rgba(var(--bs-primary-rgb, 13, 110, 253), 0.02));
+}
+
+.livingword-hero h2 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.livingword-hero-sub {
+  color: var(--bs-secondary-color, #6c757d);
+  margin-bottom: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.livingword-hero-message {
+  font-size: 0.9rem;
+  color: var(--bs-body-color, #212529);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.livingword-hero-completed_today {
+  background: linear-gradient(135deg, rgba(var(--bs-success-rgb, 25, 135, 84), 0.08), rgba(var(--bs-success-rgb, 25, 135, 84), 0.02));
+}
+
+.livingword-streak-badge {
+  display: inline-block;
+  font-size: 0.75em;
+  font-weight: 600;
+  padding: 0.2em 0.6em;
+  background: rgba(var(--bs-warning-rgb, 255, 193, 7), 0.15);
+  color: var(--bs-warning-text-emphasis, #664d03);
+  border-radius: 20px;
+  vertical-align: middle;
+  margin-left: 0.25rem;
+}
+
+.livingword-cta {
+  display: inline-block;
+  padding: 0.6rem 1.5rem;
+  background: var(--bs-primary, #0d6efd);
+  color: #fff;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1rem;
+  text-decoration: none;
+}
+
+.livingword-cta:hover {
+  background: var(--bs-primary, #0d6efd);
+  opacity: 0.9;
+  color: #fff;
+}
+
+/* ── Dashboard Stats Strip ── */
+.livingword-stats-strip {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.livingword-stat-item {
+  flex: 1 1 0;
+  min-width: 100px;
+  text-align: center;
+  padding: 0.75rem 0.5rem;
+  background: var(--bs-light, #f8f9fa);
+  border-radius: 8px;
+}
+
+.livingword-stat-value {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--bs-body-color, #212529);
+  line-height: 1.2;
+}
+
+.livingword-stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--bs-secondary-color, #6c757d);
+  margin-top: 0.15rem;
+}
+
+.livingword-stats-guest .livingword-stat-item {
+  background: transparent;
+}
+
+/* ── Milestone nudge ── */
+.livingword-milestone {
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--bs-warning-text-emphasis, #664d03);
+  background: rgba(var(--bs-warning-rgb, 255, 193, 7), 0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+}
+
 /* ── Navigation menu ── */
 .livingword-menu {
   margin-bottom: 1.5rem;

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -51,8 +51,18 @@ COM_LIVINGWORD_PASSAGES_COMPLETED="%d of %d passages completed"
 
 ; Progress
 COM_LIVINGWORD_PROGRESS_PERCENT="%d%% Complete"
+COM_LIVINGWORD_PROGRESS_PERCENT_LABEL="Complete"
 COM_LIVINGWORD_PROGRESS_DAYS="%d of %d readings completed"
 COM_LIVINGWORD_MONTH_DAYS="%d readings"
+
+; Dashboard
+COM_LIVINGWORD_WELCOME_NEW="Welcome to your Bible reading journey"
+COM_LIVINGWORD_WELCOME_BACK="Welcome back!"
+COM_LIVINGWORD_START_READING="Start Today's Reading"
+COM_LIVINGWORD_COMPLETED_TODAY="Great job completing today's reading!"
+COM_LIVINGWORD_THIS_WEEK="This Week"
+COM_LIVINGWORD_MILESTONE_STREAK="%d more days to match your best streak of %d"
+COM_LIVINGWORD_MILESTONE_PROGRESS="%d more readings to reach %d%%"
 
 ; Streaks
 COM_LIVINGWORD_STREAKS="Reading Streaks"

--- a/site/src/Model/CwmhomeModel.php
+++ b/site/src/Model/CwmhomeModel.php
@@ -21,6 +21,7 @@ use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * Home/main view model — user settings and today's reading.
@@ -80,10 +81,29 @@ class CwmhomeModel extends BaseDatabaseModel
 
         $partnerProgress = null;
         $todayNote       = '';
+        $weeklyProgress  = 0;
+        $greetingContext = 'guest';
+        $nextMilestone   = null;
 
         if ($userId > 0) {
             $partnerProgress = CwmpartnerHelper::getPartnerProgress($db, $userId);
             $todayNote       = CwmnotesHelper::getNote($db, $userId, $planId, $currentDay) ?? '';
+            $weeklyProgress  = self::getWeeklyProgress($db, $userId, $planId);
+
+            if ($completedCount === 0) {
+                $greetingContext = 'new_user';
+            } elseif ($isCompleted) {
+                $greetingContext = 'completed_today';
+            } else {
+                $greetingContext = 'returning';
+            }
+
+            $nextMilestone = self::calculateMilestone(
+                $completedCount,
+                $totalDays,
+                (int) ($userData->streak_current ?? 0),
+                (int) ($userData->streak_best ?? 0)
+            );
         }
 
         return (object) [
@@ -101,6 +121,84 @@ class CwmhomeModel extends BaseDatabaseModel
             'partnerProgress'   => $partnerProgress,
             'durationType'      => $planInfo->duration_type ?? 'annual',
             'todayNote'         => $todayNote,
+            'greetingContext'   => $greetingContext,
+            'weeklyProgress'    => $weeklyProgress,
+            'nextMilestone'     => $nextMilestone,
         ];
+    }
+
+    /**
+     * Count readings completed in the last 7 days.
+     *
+     * @param   DatabaseInterface  $db      Database
+     * @param   int                $userId  User ID
+     * @param   int                $planId  Plan ID
+     *
+     * @return  int
+     *
+     * @since   5.4.0
+     */
+    private static function getWeeklyProgress(DatabaseInterface $db, int $userId, int $planId): int
+    {
+        $weekAgo = (new \DateTime('-7 days'))->format('Y-m-d H:i:s');
+
+        $query = $db->getQuery(true)
+            ->select('COUNT(DISTINCT ' . $db->quoteName('day') . ')')
+            ->from($db->quoteName('#__livingword_progress'))
+            ->where($db->quoteName('user_id') . ' = ' . $userId)
+            ->where($db->quoteName('plan_id') . ' = ' . $planId)
+            ->where($db->quoteName('completed_at') . ' >= ' . $db->quote($weekAgo));
+
+        $db->setQuery($query);
+
+        return (int) $db->loadResult();
+    }
+
+    /**
+     * Calculate the next motivational milestone.
+     *
+     * @param   int  $completed      Completed readings
+     * @param   int  $total          Total readings
+     * @param   int  $streakCurrent  Current streak
+     * @param   int  $streakBest     Best streak
+     *
+     * @return  ?object  {type, message_key, values} or null
+     *
+     * @since   5.4.0
+     */
+    private static function calculateMilestone(int $completed, int $total, int $streakCurrent, int $streakBest): ?object
+    {
+        // Streak milestone: close to matching or beating best
+        if ($streakBest > 0 && $streakCurrent > 0 && $streakCurrent < $streakBest) {
+            $gap = $streakBest - $streakCurrent;
+
+            if ($gap <= 7) {
+                return (object) [
+                    'type'   => 'streak',
+                    'key'    => 'COM_LIVINGWORD_MILESTONE_STREAK',
+                    'values' => [$gap, $streakBest],
+                ];
+            }
+        }
+
+        // Progress milestone: next 10% boundary
+        if ($total > 0) {
+            $currentPercent = ($completed / $total) * 100;
+            $nextBoundary   = (int) (ceil(($currentPercent + 0.1) / 10) * 10);
+
+            if ($nextBoundary <= 100) {
+                $needed = (int) ceil(($nextBoundary / 100) * $total) - $completed;
+
+                if ($needed > 0 && $needed <= 30) {
+                    return (object) [
+                        'type'   => 'progress',
+                        'key'    => 'COM_LIVINGWORD_MILESTONE_PROGRESS',
+                        'values' => [$needed, $nextBoundary],
+                    ];
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/site/tmpl/cwmhome/default.php
+++ b/site/tmpl/cwmhome/default.php
@@ -35,6 +35,13 @@ $isSelfPaced       = $durationType === 'self_paced';
 $progressUrl       = Route::_('index.php?option=com_livingword&task=cwmprogress.toggle&format=json', false);
 $hasScripture      = CwmscriptureHelper::isLibraryAvailable();
 
+// Dashboard data
+$greetingContext = $data->greetingContext ?? 'guest';
+$weeklyProgress  = $data->weeklyProgress ?? 0;
+$nextMilestone   = $data->nextMilestone ?? null;
+$streakCurrent   = (int) ($user->streak_current ?? 0);
+$streakBest      = (int) ($user->streak_best ?? 0);
+
 /** @var \Joomla\CMS\Document\HtmlDocument $doc */
 $doc = $this->getDocument();
 $wa  = $doc->getWebAssetManager();
@@ -62,52 +69,104 @@ if ($showAudio && $reading) {
 <div class="com-livingword-home">
     <?php echo $this->menu; ?>
 
-    <?php // ── Plan Header ── ?>
-    <?php if ($plan) : ?>
-        <div class="livingword-plan-header">
-            <h2><?php echo $this->escape($plan->description); ?></h2>
-            <?php if (!empty($plan->message)) : ?>
-                <div class="livingword-plan-message"><?php echo $plan->message; ?></div>
-            <?php endif; ?>
-        </div>
-    <?php endif; ?>
-
-    <?php // ── Progress Bar ── ?>
-    <?php if ($isLoggedIn && $data->totalDays > 0) : ?>
-        <div class="livingword-progress-info mb-4">
-            <div class="d-flex justify-content-between align-items-center mb-1">
-                <span class="livingword-day-indicator">
-                    <?php echo Text::sprintf($isSelfPaced ? 'COM_LIVINGWORD_READING_OF' : 'COM_LIVINGWORD_DAY_OF', $data->currentDay, $data->totalDays); ?>
-                </span>
-                <span class="badge bg-primary rounded-pill"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_PERCENT', $data->progressPercent); ?></span>
-            </div>
-            <div class="progress" style="height: 6px;" role="progressbar"
-                 aria-valuenow="<?php echo $data->progressPercent; ?>" aria-valuemin="0" aria-valuemax="100">
-                <div class="progress-bar bg-success" style="width: <?php echo $data->progressPercent; ?>%"></div>
-            </div>
-            <div class="d-flex justify-content-between align-items-center mt-1">
-                <small class="text-muted"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_DAYS', $data->completedCount, $data->totalDays); ?></small>
-                <?php if ((int) ($user->streak_current ?? 0) > 0) : ?>
-                    <small class="text-muted">
-                        <?php echo Text::sprintf('COM_LIVINGWORD_STREAK_CURRENT', (int) $user->streak_current); ?>
-                        <?php if ((int) ($user->streak_best ?? 0) > (int) ($user->streak_current ?? 0)) : ?>
-                            &middot; <?php echo Text::sprintf('COM_LIVINGWORD_STREAK_BEST', (int) $user->streak_best); ?>
-                        <?php endif; ?>
-                    </small>
+    <?php // ── Section 1: Hero / Welcome ── ?>
+    <div class="livingword-hero livingword-hero-<?php echo $greetingContext; ?> mb-4">
+        <?php if ($greetingContext === 'completed_today') : ?>
+            <div class="livingword-hero-inner">
+                <h2><?php echo Text::_('COM_LIVINGWORD_COMPLETED_TODAY'); ?></h2>
+                <?php if ($plan) : ?>
+                    <p class="livingword-hero-sub"><?php echo $this->escape($plan->description); ?></p>
                 <?php endif; ?>
             </div>
+        <?php elseif ($greetingContext === 'new_user') : ?>
+            <div class="livingword-hero-inner">
+                <h2><?php echo Text::_('COM_LIVINGWORD_WELCOME_NEW'); ?></h2>
+                <?php if ($plan) : ?>
+                    <p class="livingword-hero-sub"><?php echo $this->escape($plan->description); ?></p>
+                    <?php if (!empty($plan->message)) : ?>
+                        <div class="livingword-hero-message"><?php echo $plan->message; ?></div>
+                    <?php endif; ?>
+                <?php endif; ?>
+                <?php if ($reading) : ?>
+                    <a href="#todays-reading" class="btn livingword-cta mt-2">
+                        <?php echo Text::_('COM_LIVINGWORD_START_READING'); ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+        <?php elseif ($greetingContext === 'returning') : ?>
+            <div class="livingword-hero-inner">
+                <h2>
+                    <?php echo Text::_('COM_LIVINGWORD_WELCOME_BACK'); ?>
+                    <?php if ($streakCurrent > 1) : ?>
+                        <span class="livingword-streak-badge"><?php echo Text::sprintf('COM_LIVINGWORD_STREAK_CURRENT', $streakCurrent); ?></span>
+                    <?php endif; ?>
+                </h2>
+                <?php if ($plan) : ?>
+                    <p class="livingword-hero-sub"><?php echo $this->escape($plan->description); ?></p>
+                <?php endif; ?>
+            </div>
+        <?php else : ?>
+            <?php // Guest ?>
+            <div class="livingword-hero-inner">
+                <?php if ($plan) : ?>
+                    <h2><?php echo $this->escape($plan->description); ?></h2>
+                    <?php if (!empty($plan->message)) : ?>
+                        <div class="livingword-hero-message"><?php echo $plan->message; ?></div>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <?php // ── Section 2: Dashboard Stats Strip ── ?>
+    <?php if ($isLoggedIn && $data->totalDays > 0 && $data->completedCount > 0) : ?>
+        <div class="livingword-stats-strip mb-4">
+            <div class="livingword-stat-item">
+                <span class="livingword-stat-value"><?php echo $data->progressPercent; ?>%</span>
+                <span class="livingword-stat-label"><?php echo Text::_('COM_LIVINGWORD_PROGRESS_PERCENT_LABEL'); ?></span>
+                <div class="progress mt-1" style="height: 4px; width: 100%;">
+                    <div class="progress-bar bg-success" style="width: <?php echo $data->progressPercent; ?>%"></div>
+                </div>
+            </div>
+            <div class="livingword-stat-item">
+                <span class="livingword-stat-value">
+                    <?php echo Text::sprintf($isSelfPaced ? 'COM_LIVINGWORD_READING_OF' : 'COM_LIVINGWORD_DAY_OF', $data->currentDay, $data->totalDays); ?>
+                </span>
+                <span class="livingword-stat-label"><?php echo Text::sprintf('COM_LIVINGWORD_PROGRESS_DAYS', $data->completedCount, $data->totalDays); ?></span>
+            </div>
+            <div class="livingword-stat-item">
+                <span class="livingword-stat-value"><?php echo $weeklyProgress; ?>/7</span>
+                <span class="livingword-stat-label"><?php echo Text::_('COM_LIVINGWORD_THIS_WEEK'); ?></span>
+            </div>
+            <?php if ($streakCurrent > 0) : ?>
+                <div class="livingword-stat-item">
+                    <span class="livingword-stat-value"><?php echo $streakCurrent; ?></span>
+                    <span class="livingword-stat-label"><?php echo Text::_('COM_LIVINGWORD_STREAK_CURRENT_LABEL'); ?></span>
+                </div>
+            <?php endif; ?>
         </div>
-    <?php elseif (!$isLoggedIn) : ?>
-        <div class="mb-4">
-            <span class="livingword-day-indicator">
-                <?php echo Text::sprintf('COM_LIVINGWORD_DAY_OF', $data->currentDay, $data->totalDays); ?>
-            </span>
+
+        <?php // ── Milestone nudge ── ?>
+        <?php if ($nextMilestone) : ?>
+            <div class="livingword-milestone mb-4">
+                <span class="icon-star" aria-hidden="true"></span>
+                <?php echo Text::sprintf($nextMilestone->key, ...$nextMilestone->values); ?>
+            </div>
+        <?php endif; ?>
+
+    <?php elseif (!$isLoggedIn && $data->totalDays > 0) : ?>
+        <div class="livingword-stats-strip livingword-stats-guest mb-4">
+            <div class="livingword-stat-item">
+                <span class="livingword-stat-value">
+                    <?php echo Text::sprintf('COM_LIVINGWORD_DAY_OF', $data->currentDay, $data->totalDays); ?>
+                </span>
+            </div>
         </div>
     <?php endif; ?>
 
-    <?php // ── Today's Reading Card ── ?>
+    <?php // ── Section 3: Today's Reading Card ── ?>
     <?php if ($reading) : ?>
-        <div class="card livingword-reading-card mb-4">
+        <div class="card livingword-reading-card mb-4" id="todays-reading">
             <div class="card-body">
                 <?php if ($isMultiPassage) : ?>
                     <?php // ── Multi-passage readings ── ?>
@@ -203,11 +262,11 @@ if ($showAudio && $reading) {
             </div>
         </div>
 
-        <?php // ── Study Notes / Devotional ── ?>
+        <?php // ── Section 4: Study Notes / Devotional ── ?>
         <?php
-        $descripText = trim($reading->descrip ?? '');
+        $descripText  = trim($reading->descrip ?? '');
         $hasStudyText = !empty($descripText);
-        $isLongText = $hasStudyText && str_word_count(strip_tags($descripText)) > 150;
+        $isLongText   = $hasStudyText && str_word_count(strip_tags($descripText)) > 150;
         ?>
         <?php if ($hasStudyText) : ?>
             <div class="card livingword-study-card mb-4">
@@ -221,7 +280,6 @@ if ($showAudio && $reading) {
                             <?php echo $reading->descrip; ?>
                         </div>
                         <button type="button" class="btn btn-sm btn-link p-0 mt-2 livingword-study-toggle"
-                                data-bs-toggle="collapse" data-bs-target="#studyContentFull"
                                 onclick="this.closest('.card-body').querySelector('.livingword-study-content').classList.toggle('livingword-study-collapsed'); this.textContent = this.textContent.trim() === '<?php echo Text::_('COM_LIVINGWORD_READ_MORE'); ?>' ? '<?php echo Text::_('COM_LIVINGWORD_READ_LESS'); ?>' : '<?php echo Text::_('COM_LIVINGWORD_READ_MORE'); ?>';">
                             <?php echo Text::_('COM_LIVINGWORD_READ_MORE'); ?>
                         </button>
@@ -234,7 +292,7 @@ if ($showAudio && $reading) {
             </div>
         <?php endif; ?>
 
-        <?php // ── Audio Player ── ?>
+        <?php // ── Section 5: Audio Player ── ?>
         <?php if ($showAudio) : ?>
             <div class="livingword-audio-section mb-4"
                  data-livingword-audio
@@ -250,7 +308,7 @@ if ($showAudio && $reading) {
             </div>
         <?php endif; ?>
 
-        <?php // ── Journal / Notes ── ?>
+        <?php // ── Section 6: Journal / Notes ── ?>
         <?php if ($isLoggedIn) : ?>
             <div class="card livingword-journal-card mb-4"
                  data-livingword-notes
@@ -272,18 +330,19 @@ if ($showAudio && $reading) {
                 </div>
             </div>
         <?php endif; ?>
+
     <?php else : ?>
         <div class="alert alert-info"><?php echo Text::_('COM_LIVINGWORD_NO_READING_TODAY'); ?></div>
     <?php endif; ?>
 
-    <?php // ── Actions ── ?>
+    <?php // ── Section 7: Actions ── ?>
     <div class="livingword-actions mb-4">
         <a href="<?php echo Route::_('index.php?option=com_livingword&view=cwmplanview'); ?>" class="btn btn-outline-primary">
             <?php echo Text::_('COM_LIVINGWORD_VIEW_FULL_PLAN'); ?>
         </a>
     </div>
 
-    <?php // ── Partner Progress ── ?>
+    <?php // ── Section 8: Partner Progress ── ?>
     <?php
     $partner = $data->partnerProgress ?? null;
 


### PR DESCRIPTION
## Summary
- **Hero section**: Context-aware welcome (new user, returning, completed today, guest)
  - New users see plan description + "Start Today's Reading" CTA button
  - Returning users see "Welcome back!" with streak badge
  - Completed users see celebration message with green gradient
  - Guests see plan description and message
- **Dashboard stats strip**: Horizontal metrics bar showing progress %, current day, weekly activity (x/7), and streak count
- **Milestone nudge**: Motivational message when close to streak record or next 10% progress boundary
- **Reorganized flow**: Hero → Stats → Reading → Study → Audio → Journal → Actions → Partner
- Removed old plan header + progress bar (replaced by hero + stats strip)
- New model fields: `greetingContext`, `weeklyProgress`, `nextMilestone`

Fixes #60

## Test plan
- [ ] New logged-in user (no completed readings) — verify "Welcome to your Bible reading journey" + CTA button
- [ ] Returning user with progress — verify "Welcome back!" + streak badge + stats strip
- [ ] User who completed today — verify green celebration hero
- [ ] Guest (not logged in) — verify plan description shown, no stats strip
- [ ] Stats strip shows correct values for progress %, day count, weekly, streak
- [ ] Milestone nudge appears when within 7 days of best streak
- [ ] Milestone nudge appears when within 30 readings of next 10% boundary
- [ ] All existing features still work: mark as read, passages, audio, study text, journal, partner

🤖 Generated with [Claude Code](https://claude.com/claude-code)