### PR TITLE
feat(tags): integrate com_tags for plans/links/groups (closes #69)

### DIFF
--- a/admin/forms/filter_cwmlinks.xml
+++ b/admin/forms/filter_cwmlinks.xml
@@ -27,6 +27,15 @@
         >
             <option value="">JOPTION_SELECT_CATEGORY</option>
         </field>
+        <field
+            name="tag"
+            type="tag"
+            label="JTAG"
+            mode="nested"
+            onchange="this.form.submit();"
+        >
+            <option value="">JOPTION_SELECT_TAG</option>
+        </field>
     </fields>
 
     <fields name="list">

--- a/admin/forms/filter_cwmplans.xml
+++ b/admin/forms/filter_cwmplans.xml
@@ -16,6 +16,15 @@
         >
             <option value="">JOPTION_SELECT_PUBLISHED</option>
         </field>
+        <field
+            name="tag"
+            type="tag"
+            label="JTAG"
+            mode="nested"
+            onchange="this.form.submit();"
+        >
+            <option value="">JOPTION_SELECT_TAG</option>
+        </field>
     </fields>
 
     <fields name="list">

--- a/admin/forms/group.xml
+++ b/admin/forms/group.xml
@@ -61,6 +61,15 @@
             <option value="private">COM_LIVINGWORD_GROUP_JOIN_PRIVATE</option>
         </field>
         <field
+            name="tags"
+            type="tag"
+            label="JTAG"
+            description="JTAG_DESC"
+            mode="nested"
+            multiple="true"
+            custom="true"
+        />
+        <field
             name="published"
             type="list"
             label="JSTATUS"

--- a/admin/forms/link.xml
+++ b/admin/forms/link.xml
@@ -44,6 +44,15 @@
             <option value="2">COM_LIVINGWORD_LINK_TARGET_NEW</option>
         </field>
         <field
+            name="tags"
+            type="tag"
+            label="JTAG"
+            description="JTAG_DESC"
+            mode="nested"
+            multiple="true"
+            custom="true"
+        />
+        <field
             name="published"
             type="list"
             label="JSTATUS"

--- a/admin/forms/plan.xml
+++ b/admin/forms/plan.xml
@@ -104,6 +104,15 @@
             showon="duration_type!:annual"
         />
         <field
+            name="tags"
+            type="tag"
+            label="JTAG"
+            description="JTAG_DESC"
+            mode="nested"
+            multiple="true"
+            custom="true"
+        />
+        <field
             name="published"
             type="list"
             label="JSTATUS"

--- a/admin/sql/updates/mysql/5.6.0.sql
+++ b/admin/sql/updates/mysql/5.6.0.sql
@@ -1,0 +1,7 @@
+-- 5.6.0: tagging support (com_tags integration).
+--
+-- No schema changes — tag persistence uses the shared #__contentitem_tag_map
+-- table that Joomla core already provides. The #__content_types rows for
+-- com_livingword.{plan,link,group} are seeded in script.php postflight()
+-- because their JSON payloads reference admin form paths and are cleaner to
+-- maintain idempotently in PHP than as raw INSERTs.

--- a/admin/src/Extension/LivingwordComponent.php
+++ b/admin/src/Extension/LivingwordComponent.php
@@ -22,6 +22,8 @@ use Joomla\CMS\Extension\BootableExtensionInterface;
 use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Tag\TagServiceInterface;
+use Joomla\CMS\Tag\TagServiceTrait;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -32,10 +34,14 @@ use Psr\Container\ContainerInterface;
 class LivingwordComponent extends MVCComponent implements
     BootableExtensionInterface,
     CategoryServiceInterface,
-    RouterServiceInterface
+    RouterServiceInterface,
+    TagServiceInterface
 {
-    use CategoryServiceTrait;
     use RouterServiceTrait;
+    use CategoryServiceTrait, TagServiceTrait {
+        CategoryServiceTrait::getTableNameForSection insteadof TagServiceTrait;
+        CategoryServiceTrait::getStateColumnForSection insteadof TagServiceTrait;
+    }
 
     /**
      * Minimum PHP version ID required (8.3.0 = 80300).
@@ -72,6 +78,8 @@ class LivingwordComponent extends MVCComponent implements
         return match ($section) {
             'tool'  => 'livingword_tools',
             'link'  => 'livingword_links',
+            'plan'  => 'livingword_plans',
+            'group' => 'livingword_groups',
             default => '',
         };
     }

--- a/admin/src/Model/CwmgroupModel.php
+++ b/admin/src/Model/CwmgroupModel.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Livingword\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Table\Table;
@@ -67,6 +68,30 @@ class CwmgroupModel extends AdminModel
     public function getTable($name = 'Cwmgroup', $prefix = '', $options = []): Table
     {
         return parent::getTable($name, $prefix, $options);
+    }
+
+    /**
+     * Load a single group and attach its current tag IDs so the edit form's
+     * tag field pre-populates. AdminModel::save() handles tag persistence
+     * automatically via plg_behaviour_taggable.
+     *
+     * @param   int|null  $pk  The id of the row to fetch.
+     *
+     * @return  mixed  Group object on success, false on failure.
+     *
+     * @since   5.6.0
+     */
+    #[\Override]
+    public function getItem($pk = null): mixed
+    {
+        $item = parent::getItem($pk);
+
+        if ($item && !empty($item->id)) {
+            $item->tags = new TagsHelper();
+            $item->tags->getTagIds((int) $item->id, 'com_livingword.group');
+        }
+
+        return $item;
     }
 
     /**

--- a/admin/src/Model/CwmlinkModel.php
+++ b/admin/src/Model/CwmlinkModel.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Livingword\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Table\Table;
 
@@ -65,6 +66,30 @@ class CwmlinkModel extends AdminModel
     public function getTable($name = 'Cwmlink', $prefix = '', $options = []): Table
     {
         return parent::getTable($name, $prefix, $options);
+    }
+
+    /**
+     * Load a single link and attach its current tag IDs so the edit form's
+     * tag field pre-populates. AdminModel::save() handles tag persistence
+     * automatically via plg_behaviour_taggable.
+     *
+     * @param   int|null  $pk  The id of the row to fetch.
+     *
+     * @return  mixed  Link object on success, false on failure.
+     *
+     * @since   5.6.0
+     */
+    #[\Override]
+    public function getItem($pk = null): mixed
+    {
+        $item = parent::getItem($pk);
+
+        if ($item && !empty($item->id)) {
+            $item->tags = new TagsHelper();
+            $item->tags->getTagIds((int) $item->id, 'com_livingword.link');
+        }
+
+        return $item;
     }
 
     /**

--- a/admin/src/Model/CwmlinksModel.php
+++ b/admin/src/Model/CwmlinksModel.php
@@ -43,6 +43,7 @@ class CwmlinksModel extends ListModel
                 'category_title', 'c.title',
                 'published', 'a.published',
                 'ordering', 'a.ordering',
+                'tag',
             ];
         }
 
@@ -68,6 +69,9 @@ class CwmlinksModel extends ListModel
         $catid = $this->getUserStateFromRequest($this->context . '.filter.catid', 'filter_catid', '');
         $this->setState('filter.catid', $catid);
 
+        $tag = $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
+        $this->setState('filter.tag', $tag);
+
         parent::populateState($ordering, $direction);
     }
 
@@ -83,6 +87,7 @@ class CwmlinksModel extends ListModel
         $id .= ':' . $this->getState('filter.search');
         $id .= ':' . $this->getState('filter.published');
         $id .= ':' . $this->getState('filter.catid');
+        $id .= ':' . serialize($this->getState('filter.tag'));
 
         return parent::getStoreId($id);
     }
@@ -137,6 +142,23 @@ class CwmlinksModel extends ListModel
 
         if (is_numeric($catid)) {
             $query->where($db->quoteName('a.catid') . ' = ' . (int) $catid);
+        }
+
+        // Filter by tag (com_tags integration)
+        $tagId = $this->getState('filter.tag');
+
+        if (!empty($tagId) && (is_numeric($tagId) || \is_array($tagId))) {
+            $tagIds = array_filter(array_map('intval', (array) $tagId));
+
+            if (!empty($tagIds)) {
+                $query->join(
+                    'INNER',
+                    $db->quoteName('#__contentitem_tag_map', 'tagmap')
+                    . ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+                    . ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_livingword.link')
+                );
+                $query->where($db->quoteName('tagmap.tag_id') . ' IN (' . implode(',', $tagIds) . ')');
+            }
         }
 
         $orderCol  = $this->state->get('list.ordering', 'c.title, a.ordering');

--- a/admin/src/Model/CwmplanModel.php
+++ b/admin/src/Model/CwmplanModel.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Livingword\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Table\Table;
 
@@ -65,6 +66,30 @@ class CwmplanModel extends AdminModel
     public function getTable($name = 'Cwmplan', $prefix = '', $options = []): Table
     {
         return parent::getTable($name, $prefix, $options);
+    }
+
+    /**
+     * Load a single plan and attach its current tag IDs so the edit form's
+     * tag field pre-populates. AdminModel::save() handles tag persistence
+     * automatically via plg_behaviour_taggable.
+     *
+     * @param   int|null  $pk  The id of the row to fetch.
+     *
+     * @return  mixed  Plan object on success, false on failure.
+     *
+     * @since   5.6.0
+     */
+    #[\Override]
+    public function getItem($pk = null): mixed
+    {
+        $item = parent::getItem($pk);
+
+        if ($item && !empty($item->id)) {
+            $item->tags = new TagsHelper();
+            $item->tags->getTagIds((int) $item->id, 'com_livingword.plan');
+        }
+
+        return $item;
     }
 
     /**

--- a/admin/src/Model/CwmplansModel.php
+++ b/admin/src/Model/CwmplansModel.php
@@ -44,6 +44,7 @@ class CwmplansModel extends ListModel
                 'testament', 'a.testament',
                 'published', 'a.published',
                 'ordering', 'a.ordering',
+                'tag',
             ];
         }
 
@@ -66,6 +67,9 @@ class CwmplansModel extends ListModel
         $published = $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '');
         $this->setState('filter.published', $published);
 
+        $tag = $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
+        $this->setState('filter.tag', $tag);
+
         parent::populateState($ordering, $direction);
     }
 
@@ -80,6 +84,7 @@ class CwmplansModel extends ListModel
     {
         $id .= ':' . $this->getState('filter.search');
         $id .= ':' . $this->getState('filter.published');
+        $id .= ':' . serialize($this->getState('filter.tag'));
 
         return parent::getStoreId($id);
     }
@@ -129,6 +134,23 @@ class CwmplansModel extends ListModel
             $query->where($db->quoteName('a.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
             $query->where($db->quoteName('a.published') . ' IN (0, 1)');
+        }
+
+        // Filter by tag (com_tags integration)
+        $tagId = $this->getState('filter.tag');
+
+        if (!empty($tagId) && (is_numeric($tagId) || \is_array($tagId))) {
+            $tagIds = array_filter(array_map('intval', (array) $tagId));
+
+            if (!empty($tagIds)) {
+                $query->join(
+                    'INNER',
+                    $db->quoteName('#__contentitem_tag_map', 'tagmap')
+                    . ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+                    . ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_livingword.plan')
+                );
+                $query->where($db->quoteName('tagmap.tag_id') . ' IN (' . implode(',', $tagIds) . ')');
+            }
         }
 
         $orderCol  = $this->state->get('list.ordering', 'a.ordering');

--- a/admin/src/Table/CwmgroupTable.php
+++ b/admin/src/Table/CwmgroupTable.php
@@ -15,6 +15,8 @@ namespace CWM\Component\Livingword\Administrator\Table;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Table\Table;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\Database\DatabaseInterface;
 
 /**
@@ -22,8 +24,10 @@ use Joomla\Database\DatabaseInterface;
  *
  * @since  5.7.0
  */
-class CwmgroupTable extends Table
+class CwmgroupTable extends Table implements TaggableTableInterface
 {
+    use TaggableTableTrait;
+
     /**
      * @var int|null
      * @since 5.7.0
@@ -130,7 +134,21 @@ class CwmgroupTable extends Table
      */
     public function __construct(&$db)
     {
+        $this->typeAlias = 'com_livingword.group';
+
         parent::__construct('#__livingword_groups', 'id', $db);
+    }
+
+    /**
+     * Get the type alias for this taggable table.
+     *
+     * @return  string
+     *
+     * @since   5.6.0
+     */
+    public function getTypeAlias(): string
+    {
+        return $this->typeAlias;
     }
 
     /**

--- a/admin/src/Table/CwmlinkTable.php
+++ b/admin/src/Table/CwmlinkTable.php
@@ -15,6 +15,8 @@ namespace CWM\Component\Livingword\Administrator\Table;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Table\Table;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\Database\DatabaseInterface;
 
 /**
@@ -22,8 +24,10 @@ use Joomla\Database\DatabaseInterface;
  *
  * @since  5.0.0
  */
-class CwmlinkTable extends Table
+class CwmlinkTable extends Table implements TaggableTableInterface
 {
+    use TaggableTableTrait;
+
     /**
      * @var int|null
      * @since 5.0.0
@@ -97,7 +101,21 @@ class CwmlinkTable extends Table
      */
     public function __construct(&$db)
     {
+        $this->typeAlias = 'com_livingword.link';
+
         parent::__construct('#__livingword_links', 'id', $db);
+    }
+
+    /**
+     * Get the type alias for this taggable table.
+     *
+     * @return  string
+     *
+     * @since   5.6.0
+     */
+    public function getTypeAlias(): string
+    {
+        return $this->typeAlias;
     }
 
     /**

--- a/admin/src/Table/CwmplanTable.php
+++ b/admin/src/Table/CwmplanTable.php
@@ -15,6 +15,8 @@ namespace CWM\Component\Livingword\Administrator\Table;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Table\Table;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\Database\DatabaseInterface;
 
 /**
@@ -22,8 +24,10 @@ use Joomla\Database\DatabaseInterface;
  *
  * @since  5.0.0
  */
-class CwmplanTable extends Table
+class CwmplanTable extends Table implements TaggableTableInterface
 {
+    use TaggableTableTrait;
+
     /**
      * @var int|null
      * @since 5.0.0
@@ -146,7 +150,21 @@ class CwmplanTable extends Table
      */
     public function __construct(&$db)
     {
+        $this->typeAlias = 'com_livingword.plan';
+
         parent::__construct('#__livingword_plans', 'id', $db);
+    }
+
+    /**
+     * Get the type alias for this taggable table.
+     *
+     * @return  string
+     *
+     * @since   5.6.0
+     */
+    public function getTypeAlias(): string
+    {
+        return $this->typeAlias;
     }
 
     /**

--- a/admin/tmpl/cwmgroup/edit.php
+++ b/admin/tmpl/cwmgroup/edit.php
@@ -123,6 +123,7 @@ $this->getDocument()->getWebAssetManager()->useScript('form.validate');
             <div class="col-lg-3">
                 <?php echo $this->form->renderField('join_mode'); ?>
                 <?php echo $this->form->renderField('published'); ?>
+                <?php echo $this->form->renderField('tags'); ?>
                 <?php echo $this->form->renderField('ordering'); ?>
                 <?php echo $this->form->renderField('id'); ?>
             </div>

--- a/admin/tmpl/cwmlink/edit.php
+++ b/admin/tmpl/cwmlink/edit.php
@@ -28,6 +28,7 @@ $this->getDocument()->getWebAssetManager()->useScript('form.validate');
             <div class="col-lg-3">
                 <?php echo $this->form->renderField('published'); ?>
                 <?php echo $this->form->renderField('catid'); ?>
+                <?php echo $this->form->renderField('tags'); ?>
                 <?php echo $this->form->renderField('target'); ?>
                 <?php echo $this->form->renderField('ordering'); ?>
                 <?php echo $this->form->renderField('id'); ?>

--- a/admin/tmpl/cwmplan/edit.php
+++ b/admin/tmpl/cwmplan/edit.php
@@ -52,6 +52,7 @@ $this->getDocument()->getWebAssetManager()
                     </div>
                 <?php endif; ?>
                 <?php echo $this->form->renderField('testament'); ?>
+                <?php echo $this->form->renderField('tags'); ?>
                 <?php echo $this->form->renderField('id'); ?>
             </div>
         </div>

--- a/build/pkg_livingword.xml
+++ b/build/pkg_livingword.xml
@@ -7,8 +7,8 @@
     <authorUrl>https://www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>5.5.0</version>
-    <creationDate>2026-05-17</creationDate>
+    <version>5.6.0</version>
+    <creationDate>2026-05-19</creationDate>
     <description>CWM LivingWord package — Bible reading plans component, daily reading module, scheduled email task plugin, plus the CWM Scripture library and content plugin for in-article scripture rendering.</description>
 
     <files>

--- a/build/versions.json
+++ b/build/versions.json
@@ -1,17 +1,17 @@
 {
     "_comment": "Development version tracking - semantic versioning: major.minor.patch. Updated by cwm-release after each successful release; serves as the source of truth for @since tags during active development.",
-    "_updated": "2026-05-15",
+    "_updated": "2026-05-19",
     "current": {
-        "version": "5.4.0",
+        "version": "5.5.0",
         "description": "Last stable release (from GitHub releases)"
     },
     "next": {
-        "patch": "5.4.1",
-        "minor": "5.5.0",
+        "patch": "5.5.1",
+        "minor": "5.6.0",
         "major": "6.0.0"
     },
     "active_development": {
-        "version": "5.5.0",
+        "version": "5.6.0",
         "description": "Use this for @since tags and migrations during in-progress work"
     },
     "notes": {

--- a/livingword.xml
+++ b/livingword.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
-    <version>5.5.0</version>
-    <creationDate>2026-05-17</creationDate>
+    <version>5.6.0</version>
+    <creationDate>2026-05-19</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>COM_LIVINGWORD_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Component\Livingword</namespace>

--- a/mod_livingword/mod_livingword.xml
+++ b/mod_livingword/mod_livingword.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
-    <creationDate>2026-05-17</creationDate>
-    <version>5.5.0</version>
+    <creationDate>2026-05-19</creationDate>
+    <version>5.6.0</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_LIVINGWORD_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Livingword\Site</namespace>

--- a/plg_task_livingword/livingword.xml
+++ b/plg_task_livingword/livingword.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
-    <creationDate>2026-05-17</creationDate>
-    <version>5.5.0</version>
+    <creationDate>2026-05-19</creationDate>
+    <version>5.6.0</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>PLG_TASK_LIVINGWORD_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Task\Livingword</namespace>

--- a/script.php
+++ b/script.php
@@ -138,6 +138,10 @@ class Com_livingwordInstallerScript
             // the component to the front end.
             $this->seedMenu();
 
+            // Register #__content_types rows so com_tags can tag plans,
+            // links, and groups.
+            $this->registerContentTypes();
+
             Factory::getApplication()->enqueueMessage(
                 sprintf('CWM LivingWord %s has been installed successfully.', $version),
                 'message'
@@ -152,6 +156,10 @@ class Com_livingwordInstallerScript
             // Migrate legacy free-text link categories into #__categories.
             // Safe no-op once the legacy column is gone (5.6.0+).
             $this->migrateLinkCategories();
+
+            // Re-seed content types on every update so newly added entities
+            // (or field-mapping tweaks) reach existing installs.
+            $this->registerContentTypes();
 
             Factory::getApplication()->enqueueMessage(
                 sprintf('CWM LivingWord has been updated to version %s.', $version),
@@ -394,6 +402,212 @@ class Com_livingwordInstallerScript
         } catch (\Throwable $e) {
             Factory::getApplication()->enqueueMessage(
                 'LivingWord: link category migration failed — ' . $e->getMessage(),
+                'warning'
+            );
+        }
+    }
+
+    /**
+     * Seed (or refresh) #__content_types rows for our taggable entities so
+     * com_tags can list/route them. Idempotent — UPDATEs on re-run so we
+     * never duplicate, and so field-mapping changes ship automatically.
+     *
+     * @return  void
+     *
+     * @since   5.6.0
+     */
+    private function registerContentTypes(): void
+    {
+        $namespace = 'CWM\\\\Component\\\\Livingword\\\\Administrator\\\\Table\\\\';
+        $corePrefix = 'Joomla\\\\CMS\\\\Table\\\\';
+
+        $entities = [
+            [
+                'alias'      => 'com_livingword.plan',
+                'title'      => 'Plan',
+                'tableClass' => 'CwmplanTable',
+                'dbTable'    => '#__livingword_plans',
+                'mappings'   => [
+                    'core_content_item_id' => 'id',
+                    'core_title'           => 'title',
+                    'core_state'           => 'published',
+                    'core_alias'           => 'alias',
+                    'core_created_time'    => 'created',
+                    'core_modified_time'   => 'modified',
+                    'core_body'            => 'description',
+                    'core_hits'            => 'null',
+                    'core_publish_up'      => 'null',
+                    'core_publish_down'    => 'null',
+                    'core_access'          => 'null',
+                    'core_params'          => 'null',
+                    'core_featured'        => 'null',
+                    'core_metadata'        => 'null',
+                    'core_language'        => 'null',
+                    'core_images'          => 'null',
+                    'core_urls'            => 'null',
+                    'core_version'         => 'null',
+                    'core_ordering'        => 'ordering',
+                    'core_metakey'         => 'null',
+                    'core_metadesc'        => 'null',
+                    'core_catid'           => 'null',
+                    'asset_id'             => 'null',
+                ],
+                'formFile'   => 'administrator/components/com_livingword/forms/plan.xml',
+            ],
+            [
+                'alias'      => 'com_livingword.link',
+                'title'      => 'Link',
+                'tableClass' => 'CwmlinkTable',
+                'dbTable'    => '#__livingword_links',
+                'mappings'   => [
+                    'core_content_item_id' => 'id',
+                    'core_title'           => 'name',
+                    'core_state'           => 'published',
+                    'core_alias'           => 'null',
+                    'core_created_time'    => 'null',
+                    'core_modified_time'   => 'null',
+                    'core_body'            => 'null',
+                    'core_hits'            => 'null',
+                    'core_publish_up'      => 'null',
+                    'core_publish_down'    => 'null',
+                    'core_access'          => 'null',
+                    'core_params'          => 'null',
+                    'core_featured'        => 'null',
+                    'core_metadata'        => 'null',
+                    'core_language'        => 'null',
+                    'core_images'          => 'null',
+                    'core_urls'            => 'url',
+                    'core_version'         => 'null',
+                    'core_ordering'        => 'ordering',
+                    'core_metakey'         => 'null',
+                    'core_metadesc'        => 'null',
+                    'core_catid'           => 'catid',
+                    'asset_id'             => 'null',
+                ],
+                'formFile'   => 'administrator/components/com_livingword/forms/link.xml',
+            ],
+            [
+                'alias'      => 'com_livingword.group',
+                'title'      => 'Group',
+                'tableClass' => 'CwmgroupTable',
+                'dbTable'    => '#__livingword_groups',
+                'mappings'   => [
+                    'core_content_item_id' => 'id',
+                    'core_title'           => 'name',
+                    'core_state'           => 'published',
+                    'core_alias'           => 'null',
+                    'core_created_time'    => 'created',
+                    'core_modified_time'   => 'modified',
+                    'core_body'            => 'description',
+                    'core_hits'            => 'null',
+                    'core_publish_up'      => 'null',
+                    'core_publish_down'    => 'null',
+                    'core_access'          => 'null',
+                    'core_params'          => 'null',
+                    'core_featured'        => 'null',
+                    'core_metadata'        => 'null',
+                    'core_language'        => 'null',
+                    'core_images'          => 'null',
+                    'core_urls'            => 'null',
+                    'core_version'         => 'null',
+                    'core_ordering'        => 'ordering',
+                    'core_metakey'         => 'null',
+                    'core_metadesc'        => 'null',
+                    'core_catid'           => 'null',
+                    'asset_id'             => 'null',
+                ],
+                'formFile'   => 'administrator/components/com_livingword/forms/group.xml',
+            ],
+        ];
+
+        try {
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+            foreach ($entities as $entity) {
+                $tableJson = json_encode([
+                    'special' => [
+                        'dbtable' => $entity['dbTable'],
+                        'key'     => 'id',
+                        'type'    => $entity['tableClass'],
+                        'prefix'  => $namespace,
+                        'config'  => 'array()',
+                    ],
+                    'common' => [
+                        'dbtable' => '#__ucm_content',
+                        'key'     => 'ucm_id',
+                        'type'    => 'Corecontent',
+                        'prefix'  => $corePrefix,
+                        'config'  => 'array()',
+                    ],
+                ]);
+
+                $fieldMappings = json_encode([
+                    'common'  => $entity['mappings'],
+                    'special' => new \stdClass(),
+                ]);
+
+                $historyOptions = json_encode([
+                    'formFile'      => $entity['formFile'],
+                    'hideFields'    => ['checked_out', 'checked_out_time'],
+                    'ignoreChanges' => ['modified', 'checked_out', 'checked_out_time'],
+                    'convertToInt'  => ['ordering', 'published'],
+                    'displayLookup' => [
+                        [
+                            'sourceColumn' => 'tags',
+                            'targetTable'  => '#__tags',
+                            'targetColumn' => 'id',
+                            'displayColumn' => 'title',
+                        ],
+                    ],
+                ]);
+
+                $existingId = (int) $db->setQuery(
+                    $db->getQuery(true)
+                        ->select($db->quoteName('type_id'))
+                        ->from($db->quoteName('#__content_types'))
+                        ->where($db->quoteName('type_alias') . ' = ' . $db->quote($entity['alias']))
+                )->loadResult();
+
+                if ($existingId > 0) {
+                    $update = $db->getQuery(true)
+                        ->update($db->quoteName('#__content_types'))
+                        ->set($db->quoteName('type_title') . ' = ' . $db->quote($entity['title']))
+                        ->set($db->quoteName('table') . ' = ' . $db->quote($tableJson))
+                        ->set($db->quoteName('rules') . ' = ' . $db->quote(''))
+                        ->set($db->quoteName('field_mappings') . ' = ' . $db->quote($fieldMappings))
+                        ->set($db->quoteName('router') . ' = ' . $db->quote(''))
+                        ->set($db->quoteName('content_history_options') . ' = ' . $db->quote($historyOptions))
+                        ->where($db->quoteName('type_id') . ' = ' . $existingId);
+                    $db->setQuery($update)->execute();
+
+                    continue;
+                }
+
+                $insert = $db->getQuery(true)
+                    ->insert($db->quoteName('#__content_types'))
+                    ->columns($db->quoteName([
+                        'type_title',
+                        'type_alias',
+                        'table',
+                        'rules',
+                        'field_mappings',
+                        'router',
+                        'content_history_options',
+                    ]))
+                    ->values(implode(',', [
+                        $db->quote($entity['title']),
+                        $db->quote($entity['alias']),
+                        $db->quote($tableJson),
+                        $db->quote(''),
+                        $db->quote($fieldMappings),
+                        $db->quote(''),
+                        $db->quote($historyOptions),
+                    ]));
+                $db->setQuery($insert)->execute();
+            }
+        } catch (\Throwable $e) {
+            Factory::getApplication()->enqueueMessage(
+                'LivingWord: could not register content types — ' . $e->getMessage(),
                 'warning'
             );
         }

--- a/site/src/Model/CwmresourcesModel.php
+++ b/site/src/Model/CwmresourcesModel.php
@@ -47,12 +47,16 @@ class CwmresourcesModel extends BaseDatabaseModel
             ->order($db->quoteName('c.lft') . ' ASC, ' . $db->quoteName('a.ordering') . ' ASC');
 
         $db->setQuery($query);
-        $rows = $db->loadObjectList();
+        $rows = $db->loadObjectList() ?: [];
+
+        $tagMap = $this->getTagsForLinks(array_column($rows, 'id'));
 
         $uncategorized = Text::_('COM_LIVINGWORD_UNCATEGORIZED');
         $grouped       = [];
 
         foreach ($rows as $row) {
+            $row->tags = $tagMap[(int) $row->id] ?? [];
+
             $cat             = $row->category_title !== null && $row->category_title !== ''
                 ? $row->category_title
                 : $uncategorized;
@@ -60,5 +64,50 @@ class CwmresourcesModel extends BaseDatabaseModel
         }
 
         return $grouped;
+    }
+
+    /**
+     * Load published com_tags entries for the given link IDs in one query.
+     *
+     * @param   int[]  $linkIds  Link primary keys to look up
+     *
+     * @return  array<int, \stdClass[]>  Map of link id -> array of {id, title, alias}
+     *
+     * @since   5.6.0
+     */
+    private function getTagsForLinks(array $linkIds): array
+    {
+        $linkIds = array_filter(array_map('intval', $linkIds));
+
+        if ($linkIds === []) {
+            return [];
+        }
+
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName([
+                'm.content_item_id',
+                't.id',
+                't.title',
+                't.alias',
+            ]))
+            ->from($db->quoteName('#__contentitem_tag_map', 'm'))
+            ->join(
+                'INNER',
+                $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('t.id') . ' = ' . $db->quoteName('m.tag_id')
+            )
+            ->where($db->quoteName('m.type_alias') . ' = ' . $db->quote('com_livingword.link'))
+            ->where($db->quoteName('m.content_item_id') . ' IN (' . implode(',', $linkIds) . ')')
+            ->where($db->quoteName('t.published') . ' = 1')
+            ->order($db->quoteName('t.title') . ' ASC');
+
+        $rows = $db->setQuery($query)->loadObjectList() ?: [];
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[(int) $row->content_item_id][] = $row;
+        }
+
+        return $out;
     }
 }

--- a/site/tmpl/cwmresources/default.php
+++ b/site/tmpl/cwmresources/default.php
@@ -44,6 +44,13 @@ $this->getDocument()->getWebAssetManager()
                                 <div>
                                     <h5 class="card-title mb-0"><?php echo $this->escape($link->name); ?></h5>
                                     <small class="text-muted"><?php echo $this->escape(parse_url($link->url, PHP_URL_HOST)); ?></small>
+                                    <?php if (!empty($link->tags)) : ?>
+                                        <div class="livingword-resource-tags mt-1">
+                                            <?php foreach ($link->tags as $tag) : ?>
+                                                <span class="badge bg-light text-dark border me-1"><?php echo $this->escape($tag->title); ?></span>
+                                            <?php endforeach; ?>
+                                        </div>
+                                    <?php endif; ?>
                                 </div>
                                 <?php if ($link->target == 2) : ?>
                                     <span class="icon-out-2 text-muted ms-auto flex-shrink-0" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

Integrates Joomla's built-in tagging system (`com_tags`) so reading plans, resource links, and groups can be tagged. Tags persist via `#__contentitem_tag_map`, are discoverable from the Tag Manager, filterable in admin list views, and shown as badges on the public resources page.

Implements all 8 steps from #69 (core + admin filters + frontend display).

## Architecture notes

- No `TagFactory` provider needed (unlike `CategoryFactory`). `TagServiceInterface` + `TagServiceTrait` on the component class is sufficient.
- Tag persistence is automatic via `plg_behaviour_taggable` — our tables only declare themselves taggable; no `store()` override required.
- Trait conflict resolution in `LivingwordComponent` resolves the `getTableNameForSection`/`getStateColumnForSection` collision between Category and Tag traits, using the standard `insteadof` pattern from `com_content`.
- Content types seeded in `script.php` postflight via idempotent SELECT-then-INSERT/UPDATE so re-runs refresh `field_mappings` without breaking existing tag mappings.

## Files changed (26)

Component class, install script + 5.6.0 SQL marker, 3 tables, 3 forms, 3 edit templates, 3 edit models, 2 admin filter forms + 2 list models, frontend resources model + template, version bump across 4 manifests + versions.json.

## Test plan

- [ ] Update from 5.5.0 → 5.6.0; confirm 3 new rows in `#__content_types`
- [ ] Edit a plan/link/group; add tags (try inline-create); save; reopen → tags still selected
- [ ] Verify entries in `#__contentitem_tag_map`
- [ ] Filter admin Plans/Links lists by tag
- [ ] Components → Tags → click tag → confirm component items listed
- [ ] Frontend Resources view → tag badges appear under tagged links
- [ ] CI passes (PHPUnit 52/52 + lint clean locally)

## Build artifact

`pkg_livingword-5.6.0.zip` — 582 KB, 6 children, 7 entries verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)