### PR TITLE
ci: call the shared joomla-package-ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,24 @@
 name: CI
 
+# The lint, test and build steps live in cwm-build-tools so every CWM
+# extension runs the same pipeline and a fix lands everywhere at once. What
+# stays here is when CI runs, and the values that differ from the shared
+# defaults.
+#
+# The reusable workflow is .github/workflows/joomla-package-ci.yml in
+# Joomla-Bible-Study/cwm-build-tools. To see what the inputs do, or to change
+# a step, edit it there.
+#
+# Removed in the migration, and worth recording so it is not re-added by
+# reflex: a MySQL 8.4 service container, a full shallow clone of joomla-cms
+# 5.4.3, a schema import, `mkdir -p tests/integration`, and the JTEST_DB_* /
+# JOOMLA_CMS_PATH environment. All of it existed for integration tests that
+# do not exist — tests/integration is empty, and nothing in the repository
+# reads any of those variables. The mkdir was there so PHPUnit would not
+# error on the missing directory. If integration tests are written later,
+# that scaffolding needs to come back deliberately, in a job of its own,
+# rather than as dead weight on every run.
+
 on:
   push:
     branches: [ "main" ]
@@ -16,94 +35,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  php-checks:
+  ci:
     name: PHP Lint & Tests
-    runs-on: ubuntu-latest
-
-    services:
-      mysql:
-        image: mysql:8.4
-        env:
-          MYSQL_USER: livingword_test
-          MYSQL_PASSWORD: livingword_test
-          MYSQL_ROOT_PASSWORD: livingword_test
-          MYSQL_DATABASE: livingword_test
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "mysqladmin ping -h 127.0.0.1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: mbstring, json, xml, mysqli
-          coverage: none
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Clone joomla-cms for test framework
-        run: git clone --depth 1 --branch 5.4.3 https://github.com/joomla/joomla-cms.git $GITHUB_WORKSPACE/../joomla-cms
-
-      - name: Install Composer dependencies
-        run: composer install --dev --no-interaction --prefer-dist
-
-      - name: Import database schema
-        run: |
-          sed 's/#__/livingword_/g' admin/sql/install.mysql.utf8.sql > /tmp/schema.sql
-          mysql --force -h 127.0.0.1 -u livingword_test -plivingword_test livingword_test < /tmp/schema.sql 2>&1 | grep -v "doesn't exist" || true
-
-      - name: Ensure integration test dir exists
-        run: mkdir -p tests/integration
-
-      - name: Check PHP syntax
-        run: composer lint:syntax
-
-      - name: Run PHPUnit tests
-        run: composer test
-        env:
-          JOOMLA_CMS_PATH: /home/runner/work/CWMLivingWord/joomla-cms
-          JTEST_DB_HOST: 127.0.0.1
-          JTEST_DB_NAME: livingword_test
-          JTEST_DB_USER: livingword_test
-          JTEST_DB_PASSWORD: livingword_test
-          JTEST_DB_PREFIX: livingword_
-
-      - name: Build package
-        run: composer build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify package contents
-        run: |
-          VERSION=$(php -r '$x = simplexml_load_file("livingword.xml"); echo (string) $x->version;')
-          PKG="build/dist/pkg_livingword-$VERSION.zip"
-          test -f "$PKG" || { echo "Package not built: $PKG"; exit 1; }
-          echo "Package contents:"
-          unzip -l "$PKG"
-          for inner in lib_cwmscripture.zip com_livingword.zip mod_livingword.zip plg_task_livingword.zip plg_content_scripturelinks.zip pkg_livingword.xml; do
-            unzip -l "$PKG" | grep -q "$inner" || { echo "Missing $inner in package"; exit 1; }
-          done
-
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pkg_livingword
-          path: build/dist/pkg_livingword-*.zip
-          retention-days: 7
+    # `v1` is a moving tag on cwm-build-tools, re-pointed at each release —
+    # the CI equivalent of the `^1.4` Composer constraint in composer.json.
+    uses: Joomla-Bible-Study/cwm-build-tools/.github/workflows/joomla-package-ci.yml@v1
+    with:
+      php-version: '8.3'
+      # PHP CS Fixer is off, matching what this project ran before the
+      # migration: `composer lint` has never been part of CI here and the
+      # tree has formatting it would reject. Turn it on in its own change,
+      # after `composer lint:fix` — not as a side effect of adopting the
+      # shared pipeline. The syntax check (`lint:syntax`) still runs.
+      run-lint: false
+      run-lint-syntax: true
+      build-command: 'composer build'
+      package-glob: 'build/dist/pkg_livingword-*.zip'

--- a/tests/integration/.gitkeep
+++ b/tests/integration/.gitkeep
@@ -1,0 +1,9 @@
+Keeps this directory in the repository while it holds no tests.
+
+phpunit.xml declares a "LivingWord Integration Tests" suite pointing here, and
+PHPUnit exits 2 on a missing test directory — so without this file a fresh
+clone cannot run `composer test` at all. CI used to paper over that with a
+`mkdir -p tests/integration` step, which meant the suite worked on the runner
+and nowhere else.
+
+Delete this file when the first integration test lands.


### PR DESCRIPTION
Replaces this repository's hand-maintained CI with a call to the shared
reusable workflow in cwm-build-tools. 90 lines out, 34 lines of "when to run"
and five inputs in.

### Most of what's removed was never doing anything

The MySQL 8.4 service container, the shallow clone of **joomla-cms 5.4.3**,
the schema import, `mkdir -p tests/integration`, and the `JTEST_DB_*` /
`JOOMLA_CMS_PATH` environment all existed for integration tests that don't
exist:

- `tests/integration/` contains **0 files**
- **nothing** in the repository reads `JTEST_DB_*` or `JOOMLA_CMS_PATH`
- the `mkdir` was there so PHPUnit wouldn't error on the missing directory

Every push has been starting a database and cloning the whole of Joomla to run
52 unit tests. If integration tests get written, that setup should come back
deliberately, in its own job — the workflow comments record what it was.

### One of those pieces turned out to be load-bearing

Dropping `mkdir -p tests/integration` failed the first CI run:

```
Test directory ".../tests/integration" not found
Script phpunit handling the test event returned with error code 2
```

`phpunit.xml` declares a `LivingWord Integration Tests` suite pointing at a
directory git cannot track, because it is empty. **`composer test` has
therefore been failing on any fresh clone of this repository** — it worked on
the runner only because the workflow created the directory first, and works
on existing laptops only because the directory is already there.

Fixed at the cause rather than by re-adding the `mkdir`: `tests/integration/.gitkeep`
puts the directory in every checkout, so the suite behaves the same on a
runner and on a laptop. Delete it when the first integration test lands.

### What's kept, and why

| Input | Value | Why |
|---|---|---|
| `php-version` | `'8.3'` | matches what this repo pinned |
| `run-lint` | `false` | **PHP CS Fixer stays off** — see below |
| `run-lint-syntax` | `true` | `composer lint:syntax` runs, as it does today |
| `build-command` / `package-glob` | project paths | |

`composer lint` has never run in CI here and the tree has formatting it would
reject. Enabling it as a side effect of adopting the shared pipeline would
fail CI on unrelated code, so it stays off — that's a separate change, after
`composer lint:fix`. The new `run-lint-syntax` input exists precisely so
those two can be decided independently.

The manual inner-entry assertion (`unzip -l | grep` for each member zip) is
dropped because the build already enforces it: `Packager` throws when an
`includes[]` entry can't be resolved, so a missing member fails the build
rather than the check after it. The workflow still lists package contents.

### Requires cwm-build-tools v1.11.0

Two of its changes exist because of this migration:

- `run-lint-syntax`, so the syntax check and the fixer can be gated separately
- `GITHUB_TOKEN` on the build step — `build/fetch_dependencies.php` pulls three
  scripture zips from the releases API, which **this repo's own workflow
  authenticated and the shared one did not**. Unauthenticated is 60 requests
  an hour shared across every job on the runner's IP.

### What to look for in review

Confirm the run still builds `pkg_livingword-*.zip` with all six inner
entries, and that dropping the DB/joomla-cms setup doesn't change the test
count (`composer test` should report the same tests as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
