### PR TITLE
fix(update): declare ARS update server on the package manifest

### DIFF
--- a/build/pkg_livingword.xml
+++ b/build/pkg_livingword.xml
@@ -11,6 +11,17 @@
     <creationDate>2026-05-19</creationDate>
     <description>CWM LivingWord package — Bible reading plans component, daily reading module, scheduled email task plugin, plus the CWM Scripture library and content plugin for in-article scripture rendering.</description>
 
+    <!-- ARS update stream 6 (see cwm-build.config.json ars.updateStreamId).
+         The task=stream parameter is required — without it ARS falls back to
+         task=all and returns an <extensionset> category index instead of the
+         <updates> document Joomla's extension update adapter expects.
+         The trailing dummy=extension.xml is ignored by ARS; it exists so
+         proxies and caches that sniff the URL extension see an .xml file.
+         Matches pkg_proclaim.xml. -->
+    <updateservers>
+        <server type="extension" name="CWM LivingWord Package">https://www.christianwebministries.org/index.php?option=com_ars&amp;view=update&amp;task=stream&amp;format=xml&amp;id=6&amp;dummy=extension.xml</server>
+    </updateservers>
+
     <files>
         <file type="library" id="cwmscripture">lib_cwmscripture.zip</file>
         <file type="component" id="com_livingword">com_livingword.zip</file>


### PR DESCRIPTION
## Problem

`pkg_livingword` shipped with **no `<updateservers>` block at all** — a `grep` for `updateservers` across every manifest in the repo returned zero hits. Sites that installed the package therefore never saw a LivingWord update in Joomla's Extension Manager. Every sibling CWM extension declares one; LivingWord was the outlier.

## Fix

Points the package manifest at ARS update stream 6 (`ars.updateStreamId` in `cwm-build.config.json`).

Two details in the URL, both deliberate:

- **`task=stream` is required.** Without it ARS falls back to `task=all` and returns an `<extensionset>` category index instead of the `<updates>` document Joomla's extension update adapter expects. Confirmed against `release-system/component/frontend/src/View/Update/XmlView.php:44`. The scripture manifests had this same bug and are fixed in companion PRs.
- **`dummy=extension.xml`** is ignored by ARS; it's there for proxies that sniff the URL extension. Matches `pkg_proclaim.xml`.

## Verification

Parsed the manifest and fetched the exact URL SimpleXML decodes:

```
HTTP 200; root=<updates>; updates=2; latest=5.4.0
```

Previously the same request returned `root=<extensionset>`.

## Known follow-ups (ARS-side, not fixed here)

This restores *reachability* of the stream, not its contents. Both still need attention in ARS admin before users benefit:

- Stream 6 advertises **5.4.0** while GitHub is at **5.5.0** — 5.4.1 and 5.5.0 were never published to ARS.
- The stream's element field is `pkg_livingword ` with a **trailing space**. On MySQL 8 with Joomla's default `utf8mb4_0900_ai_ci` (NO PAD) that won't match `#__extensions.element`, so the update stays invisible regardless of this manifest. Streams 4 and 5 are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)