### PR TITLE
chore(deps): adopt cwm/build-tools ^1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "ext-zip": "*"
   },
   "require-dev": {
-    "cwm/build-tools": "^1.4",
+    "cwm/build-tools": "^1.13",
     "phpunit/phpunit": "^12.5",
     "friendsofphp/php-cs-fixer": "^3.0",
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17ef3ce93cf968aa5768c82167d4fe37",
+    "content-hash": "021a0bcc862e908954cf3967fa7c41df",
     "packages": [],
     "packages-dev": [
         {
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.13.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "ef781c7d1a7de5461e284ce9e683e260f19675c5"
+                "reference": "45301cfbb189e69298ab30cf9800ca76d507e28d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/ef781c7d1a7de5461e284ce9e683e260f19675c5",
-                "reference": "ef781c7d1a7de5461e284ce9e683e260f19675c5",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/45301cfbb189e69298ab30cf9800ca76d507e28d",
+                "reference": "45301cfbb189e69298ab30cf9800ca76d507e28d",
                 "shasum": ""
             },
             "require": {
@@ -401,10 +401,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.13.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.13.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-30T04:46:43+00:00"
+            "time": "2026-07-30T20:37:58+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Picks up [cwm/build-tools v1.13.1](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.13.1).

## Why

1.13.1 fixes `cwm-changelog` splicing generated entries into the changelog file's header comment — either losing the entry silently or leaving the document unparseable. The vendored copy here was still v1.13.0 with the old code.

Also raises the constraint from `^1.4` to `^1.13`, recording the version this project is actually developed against. Note this does not by itself guarantee the fix — `^1.13` still permits 1.13.0 — but `composer update` resolves to the newest match, and `composer.lock` pins v1.13.1 for everyone.

## Verification

```
composer.lock:      v1.13.1  45301cfbb189
composer validate:  ./composer.json is valid
```

Dev dependency only — `composer.json` and `composer.lock` are excluded from the built package, so the shipped artifact is unchanged.

Companion PRs: Joomla-Bible-Study/lib_cwmscripture#31, Joomla-Bible-Study/CWMScriptureLinks#16, Joomla-Bible-Study/Proclaim#1379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)