### PR TITLE
chore(ci): enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot version updates.
+#
+# Security updates run without this file; version updates need it.
+#
+# Minor and patch bumps are grouped into a single PR per ecosystem — most of
+# the Composer dev dependencies are joomla/* packages that move together, and
+# ungrouped they would open nine PRs for one Joomla release. Major bumps stay
+# separate, since those want reading.
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      composer-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # cwm/build-tools is sourced from a Composer VCS repository (see
+      # composer.json "repositories"). Dependabot's Composer support does not
+      # resolve VCS repositories — it looks the package up on Packagist, where
+      # it does not exist — so it would never open a PR for it regardless.
+      # Listed explicitly so its absence reads as a decision, not an oversight.
+      # Bump it by hand: composer update cwm/build-tools
+      - dependency-name: "cwm/build-tools"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Security updates already run without a config file; **version updates need one**, which is why none of these repos has been getting routine dependency PRs.

## What it covers

| Ecosystem | Tracks |
|---|---|
| `composer` | The Packagist dependencies — phpunit, php-cs-fixer, roave/security-advisories, joomla/* |
| `npm` | The build-pipeline devDependencies (rollup, eslint, csso) |
| `github-actions` | Action versions pinned in the workflows |

Weekly, Mondays, 5 PRs per ecosystem max. Minor and patch bumps are **grouped into one PR per ecosystem** — nine of the Composer dev dependencies are `joomla/*` packages that move together, and ungrouped they'd open nine PRs for a single Joomla release. Major bumps stay separate, since those want reading.

Commit prefixes are `chore(deps)` / `chore(deps-dev)` / `ci`, matching the conventional-commit history.

## What it deliberately does not cover

`cwm/build-tools` is listed under `ignore`. It's sourced from a Composer **VCS repository**, and Dependabot's Composer support doesn't resolve those — it looks the package up on Packagist, where it doesn't exist, so it would never open a PR for it regardless of config. The [feedback issue](https://github.com/dependabot/feedback/issues/692) reporting this was never resolved and the repo was archived in 2022.

Listing it explicitly makes the gap read as a decision rather than an oversight. It stays a manual `composer update cwm/build-tools`, as done today for v1.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)