### PR TITLE
fix(test): tear down files and menu rows in the test-site reset

### DIFF
--- a/build/reset-testsite.php
+++ b/build/reset-testsite.php
@@ -140,6 +140,7 @@ foreach ($installs as $install) {
     );
 
     // 3. Rows that reference the component by name rather than by id.
+    $db->query("DELETE FROM `{$prefix}menu` WHERE link LIKE '%option=com\\_livingword%'");
     $db->query("DELETE FROM `{$prefix}assets` WHERE name = 'com_livingword' OR name LIKE 'com\\_livingword.%'");
     $db->query("DELETE FROM `{$prefix}categories` WHERE extension LIKE 'com\\_livingword%'");
     $db->query("DELETE FROM `{$prefix}content_types` WHERE type_alias LIKE 'com\\_livingword.%'");
@@ -177,7 +178,99 @@ foreach ($installs as $install) {
 
     $db->close();
 
+    // 5. Remove the files. Clearing #__extensions alone is not a reset: Joomla
+    //    refuses to install into a directory that already exists without a
+    //    matching extension row, so the next install aborts on the first child
+    //    whose folder survived — with only "[ERROR] Unable to install
+    //    extension" to go on, and the package half-installed.
+    $paths = [
+        'administrator/components/com_livingword',
+        'components/com_livingword',
+        'api/components/com_livingword',
+        'modules/mod_livingword',
+        'plugins/task/livingword',
+        'media/com_livingword',
+        'media/mod_livingword',
+        'administrator/manifests/packages/pkg_livingword.xml',
+        'administrator/manifests/packages/livingword',
+    ];
+
+    $removed  = 0;
+    $symlinks = 0;
+
+    foreach ($paths as $rel) {
+        $abs = $install->path . '/' . $rel;
+
+        // is_dir() follows symlinks, so test for the link first — recursing
+        // through one would delete the working tree it points at.
+        if (is_link($abs)) {
+            @unlink($abs);
+            $symlinks++;
+            $removed++;
+
+            continue;
+        }
+
+        if (is_file($abs)) {
+            @unlink($abs);
+            $removed++;
+
+            continue;
+        }
+
+        if (is_dir($abs)) {
+            rrmdir($abs);
+            $removed++;
+        }
+    }
+
+    // Stray language files from installs predating per-extension language dirs.
+    foreach (glob($install->path . '/administrator/language/*/com_livingword.*') ?: [] as $file) {
+        @unlink($file);
+        $removed++;
+    }
+
+    foreach (glob($install->path . '/language/*/com_livingword.*') ?: [] as $file) {
+        @unlink($file);
+        $removed++;
+    }
+
+    echo "  removed {$removed} path(s)\n";
+
+    if ($symlinks > 0) {
+        fwrite(
+            STDERR,
+            "  NOTE: unlinked {$symlinks} symlink(s) — this install was symlinked as if it were role=dev.\n"
+        );
+    }
+
     echo "  clean.\n";
+}
+
+/**
+ * Recursively remove a directory. Does not descend into symlinks.
+ */
+function rrmdir(string $dir): void
+{
+    foreach (scandir($dir) ?: [] as $entry) {
+        if ($entry === '.' || $entry === '..') {
+            continue;
+        }
+
+        $path = $dir . '/' . $entry;
+
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+
+            continue;
+        }
+
+        if (is_dir($path)) {
+            rrmdir($path);
+        }
+    }
+
+    @rmdir($dir);
 }
 
 if ($failed > 0) {


### PR DESCRIPTION
Follow-up to #94. The reset added there cleared the database but left the extension's files on disk, so `composer test:install` only worked once — against a site that had never had LivingWord on it.

## Symptom

```
→ j6-test
  ✗ extension:install exit 1
   [ERROR] Unable to install extension
```

No further detail, even at `-vv`. Joomla refuses to install into a directory that exists without a matching `#__extensions` row, and its CLI surfaces none of that.

## What actually survived

Only one path, after the first filesystem pass:

```
api/components/com_livingword
```

The API component directory — missing from my initial list, present in Proclaim's. It's misleading to diagnose, because the abort presents as the **module** failing: the component registers first, so a partial install leaves `component::com_livingword` behind and the package stops before the module.

## Fix

Following Proclaim's reset, which had all of this already:

- Filesystem teardown for every install location, including `api/components` and the package manifest. Their note explains why manifests matter: leaving one makes a fresh install register as an **update**, so it runs ALTER SQL against tables that don't exist yet.
- `#__menu` rows, which the DB pass also missed.
- **Symlinks are unlinked, never recursed into.** `is_dir()` is true for a symlink to a directory, so recursing would empty the *target* — the repo's own source, if a `role=test` site were ever linked. Proclaim warns and drops the link; this does the same.

## Verified

Repeatable now — reset, build, install, twice in a row from a dirty site:

```
component::com_livingword   v=5.6.0-beta1  enabled=1
module::mod_livingword      v=5.6.0-beta1  enabled=1
package::pkg_livingword     v=5.6.0-beta1  enabled=1
plugin:task:livingword      v=5.6.0-beta1  enabled=0
livingword tables: 9
```

Step 4 still exits 1 on `plg_task_livingword — needs enabled = 1`. That's #96, not this — the install itself is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)