### PR TITLE
fix(install): repair idx_action_token on existing installs; bump to 5.6.0

### DIFF
--- a/build/pkg_livingword.xml
+++ b/build/pkg_livingword.xml
@@ -7,7 +7,7 @@
     <authorUrl>https://www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>5.6.0-beta2</version>
+    <version>5.6.0</version>
     <creationDate>2026-07-30</creationDate>
     <description>CWM LivingWord package — Bible reading plans component, daily reading module, scheduled email task plugin, plus the CWM Scripture library and content plugin for in-article scripture rendering.</description>
 

--- a/build/test-release.sh
+++ b/build/test-release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Full release gate: clean install, then upgrade from the last release.
+#
+# Runs both suites even when the first fails, then reports. A composer script
+# array (["@test:install", "@test:upgrade"]) stops at the first non-zero exit,
+# which meant a known registration drift hid the upgrade run entirely — and the
+# upgrade path is the half that carries real users.
+#
+# Run via: composer test:release
+#
+# @package  Livingword.Build
+# @since    __DEPLOY_VERSION__
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAILED=()
+
+echo "########################################################################"
+echo "# 1/2  CLEAN INSTALL"
+echo "########################################################################"
+bash build/test-install.sh || FAILED+=("clean install")
+
+echo
+echo "########################################################################"
+echo "# 2/2  UPGRADE FROM LAST RELEASE"
+echo "########################################################################"
+bash build/test-upgrade.sh || FAILED+=("upgrade")
+
+echo
+echo "========================================================================"
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+    echo " RELEASE GATE FAILED:"
+    for f in "${FAILED[@]}"; do
+        echo "   - ${f}"
+    done
+    echo "========================================================================"
+    exit 1
+fi
+
+echo " RELEASE GATE PASSED — clean install and upgrade both verified."
+echo "========================================================================"

--- a/build/versions.json
+++ b/build/versions.json
@@ -11,7 +11,7 @@
         "major": "6.0.0"
     },
     "active_development": {
-        "version": "5.6.0-beta2",
+        "version": "5.6.0",
         "description": "Use this for @since tags and migrations during in-progress work"
     },
     "notes": {

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     "test:install":       "bash build/test-install.sh",
     "test:migrations":    "@php build/verify-migrations.php",
     "test:upgrade":       "bash build/test-upgrade.sh",
-    "test:release":       ["@test:install", "@test:upgrade"],
+    "test:release":       "bash build/test-release.sh",
     "setup":              "cwm-setup",
     "joomla-install":     "cwm-joomla-install",
     "joomla-latest":      "cwm-joomla-latest",

--- a/livingword.xml
+++ b/livingword.xml
@@ -5,7 +5,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
-    <version>5.6.0-beta2</version>
+    <version>5.6.0</version>
     <creationDate>2026-07-30</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>COM_LIVINGWORD_XML_DESCRIPTION</description>

--- a/mod_livingword/mod_livingword.xml
+++ b/mod_livingword/mod_livingword.xml
@@ -6,7 +6,7 @@
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
     <creationDate>2026-07-30</creationDate>
-    <version>5.6.0-beta2</version>
+    <version>5.6.0</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_LIVINGWORD_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Livingword\Site</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_livingword",
-  "version": "5.6.0-beta2",
+  "version": "5.6.0",
   "description": "CWM LivingWord - frontend asset build pipeline (CSS + ESLint)",
   "license": "GPL-2.0-or-later",
   "private": true,

--- a/plg_task_livingword/livingword.xml
+++ b/plg_task_livingword/livingword.xml
@@ -6,7 +6,7 @@
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
     <creationDate>2026-07-30</creationDate>
-    <version>5.6.0-beta2</version>
+    <version>5.6.0</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>PLG_TASK_LIVINGWORD_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Task\Livingword</namespace>

--- a/script.php
+++ b/script.php
@@ -142,6 +142,8 @@ class Com_livingwordInstallerScript
             // links, and groups.
             $this->registerContentTypes();
 
+            $this->ensureActionTokenIndex();
+
             Factory::getApplication()->enqueueMessage(
                 sprintf('CWM LivingWord %s has been installed successfully.', $version),
                 'message'
@@ -161,6 +163,8 @@ class Com_livingwordInstallerScript
             // (or field-mapping tweaks) reach existing installs.
             $this->registerContentTypes();
 
+            $this->ensureActionTokenIndex();
+
             Factory::getApplication()->enqueueMessage(
                 sprintf('CWM LivingWord has been updated to version %s.', $version),
                 'message'
@@ -168,6 +172,59 @@ class Com_livingwordInstallerScript
         }
 
         return true;
+    }
+
+    /**
+     * Ensure #__livingword_users carries the idx_action_token index.
+     *
+     * install.mysql.utf8.sql created the action_token column without its index
+     * while 5.3.0.sql added both, so any site installed fresh from the shipped
+     * package has the column and not the index. Update SQL cannot repair them:
+     * Joomla only runs files newer than the recorded #__schemas version, so
+     * 5.3.0.sql never fires for a site that installed at 5.6.0.
+     *
+     * CwmuserHelper::findByActionToken() filters on the column directly — the
+     * one-click "mark as read" link in every reading email — so without the
+     * index each click is a full scan of the users table.
+     *
+     * Idempotent: checks information_schema first, because MySQL has no
+     * ADD KEY IF NOT EXISTS and a duplicate-key error would surface as a
+     * failed install.
+     *
+     * @return  void
+     *
+     * @since   5.6.0
+     */
+    private function ensureActionTokenIndex(): void
+    {
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $table = $db->replacePrefix('#__livingword_users');
+
+            $query = $db->getQuery(true)
+                ->select('COUNT(*)')
+                ->from($db->quoteName('information_schema.statistics'))
+                ->where($db->quoteName('table_schema') . ' = DATABASE()')
+                ->where($db->quoteName('table_name') . ' = ' . $db->quote($table))
+                ->where($db->quoteName('index_name') . ' = ' . $db->quote('idx_action_token'));
+
+            if ((int) $db->setQuery($query)->loadResult() > 0) {
+                return;
+            }
+
+            $db->setQuery(
+                'ALTER TABLE ' . $db->quoteName($table)
+                . ' ADD KEY ' . $db->quoteName('idx_action_token')
+                . ' (' . $db->quoteName('action_token') . ')'
+            )->execute();
+        } catch (\Throwable $e) {
+            // A missing index costs performance, never correctness. Failing the
+            // install over it would be the worse outcome.
+            Factory::getApplication()->enqueueMessage(
+                'CWM LivingWord: could not create idx_action_token — ' . $e->getMessage(),
+                'warning'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Bumps to 5.6.0 so the upgrade test can run, then fixes what it found on its first real execution.

## What the upgrade test caught

```
-- [5/6] install 5.6.0 over 5.6.0-beta2 (triggers update() + migrations)
 [OK] CWM LivingWord has been updated to version 5.6.0.
-- [6/6] verify registration + schema after upgrade
 FAIL: missing index livingword_users.idx_action_token
```

**My reasoning in #101 was wrong.** I wrote there that no shipped site could be affected by the missing index "because every published package before 5.6.0-beta2 failed to install." But beta2 *is* installable and *is* shipped — so every beta tester is in exactly the broken state, and the `install.sql` fix does nothing for them.

Update SQL can't repair it either: Joomla only runs files newer than the recorded `#__schemas` version, so `5.3.0.sql` never fires for a site that installed at 5.6.0.

## Fix

An idempotent `ensureActionTokenIndex()` in postflight, on both the install and update routes:

- Checks `information_schema` first — MySQL has no `ADD KEY IF NOT EXISTS`, and a duplicate-key error would surface as a failed install
- Warns rather than aborts on failure — a missing index costs performance, never correctness

Verified: the same upgrade run now reports `Schema verified for 5.6.0`.

## `test:release` was hiding the upgrade suite

`["@test:install", "@test:upgrade"]` stops at the first non-zero exit, so the known #96 drift meant the upgrade suite never ran under `composer test:release` — the half that carries real users, and the one that had never been exercised. Replaced with `build/test-release.sh`, which runs both and reports at the end. Same fix as inside the individual harnesses.

That is now the third time this pattern has bitten: a known failure masking an unknown one. It is worth treating "abort on first failure" as a defect in any verification path.

## Current state of the gate

Both suites run; the only remaining failure in either is #96:

```
CLEAN INSTALL   → schema verified, registration drift (#96)
UPGRADE         → schema verified, registration drift (#96)
```

Once #96 is decided, `composer test:release` goes green and becomes a genuine pre-release gate.

## Note on 5.6.0-beta2

The shipped beta2 lacks the index. Anyone testing it gets the repair automatically when they update to 5.6.0 — no action needed, and no re-cut warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)