### PR TITLE
chore: sync package-lock version to 5.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_livingword",
-  "version": "5.6.0-beta2",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_livingword",
-      "version": "5.6.0-beta2",
+      "version": "5.6.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@eslint/js": "^10.0.1",


### PR DESCRIPTION
`cwm-bump` rewrites `package.json`'s version but not `package-lock.json`'s, so the lock kept `5.6.0-beta2` after the bump in #102 and showed as permanently dirty — where it would eventually be swept into an unrelated commit.

Two-line version sync, no dependency changes.

Worth fixing upstream too: `versionTracking.packageJson` is configured in `cwm-build.config.json`, so cwm-bump knows this project has a package.json. Updating the adjacent lockfile's top-level version alongside it would keep every consuming project clean. I can send that to cwm-build-tools if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)