### PR TITLE
docs(release): adopt release.notesFile, and write 5.6.0's notes

### DIFF
--- a/build/release-notes-5.6.0.md
+++ b/build/release-notes-5.6.0.md
@@ -1,0 +1,22 @@
+This release adds tagging and a working group-invitation flow — and, more importantly, it is the first LivingWord package that actually installs.
+
+Every release before 5.6.0-beta2 shipped a package Joomla refused to install: the inner extensions were assembled into a `packages/` folder the manifest never pointed at, so the installer aborted with "Unable to install extension" and nothing more. If a previous install failed for you, that is why. 5.6.0 installs and updates cleanly, and both paths are now verified against Joomla 5.4, 6.1 and 6.2 before each release rather than after.
+
+## New features
+
+- **Tagging for reading plans, resource links and groups.** Uses Joomla's own tag system, so tags are shared with the rest of your site and work with existing tag modules and searches. Tag fields appear on the edit screens for all three.
+- **Invitation links now work for people without an account.** Previously an invite link bounced anyone who was not already logged in, which is most people receiving one. Visitors now get a landing page describing the group, with the invitation preserved through registration or login so they land in the right group afterwards.
+
+## Fixes
+
+- **The package installs.** The package manifest now points at the folder its inner extensions are actually assembled into.
+- **Updates appear in the Extension Manager.** The package shipped with no update server declared at all, so no site was ever notified of a new version. It is now wired to the CWM update stream, and a Changelog tab appears alongside the update.
+- **Scheduled emails no longer need the plugin switched on by hand.** Joomla registers new plugins disabled, so the daily reading email, weekly progress digest and accountability-partner digest never ran until an admin found the plugin and enabled it — with nothing to indicate that was the problem. It is now enabled on install, and existing sites get it enabled once when they update.
+- **The one-click "mark as read" link in reading emails is no longer a full table scan.** Fresh installs were missing an index that upgraded sites had.
+- **Group member counts no longer break the page.** The member-count text used a plural form Joomla does not support, which produced a 500 error where the count was shown.
+
+## Notes
+
+- Requires PHP 8.3 or later and Joomla 5 or 6.
+- If you tested 5.6.0-beta1 or beta2, updating applies the missing index and enables the task plugin automatically. Nothing to do by hand.
+- Enabling the task plugin does not by itself send anything. The routines still need a task created under **System → Scheduled Tasks**.

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -149,6 +149,10 @@
         "repo": "CWMLivingWord",
         "releaseBranch": "main"
     },
+    "release": {
+        "_comment": "Hand-written notes lead the GitHub release body, with the generated pull-request list kept beneath. These are also what ARS republishes on the download page — the only changelog a site administrator following an update link ever sees. Use the headings cwm-changelog recognises (## New features, ## Fixes, ## Changes, ## Notes) so the same file also produces a real Joomla changelog entry instead of the install boilerplate that generated ones produced.",
+        "notesFile": "build/release-notes-{version}.md"
+    },
     "changelog": {
         "file": "build/livingword-changelog.xml",
         "url":  "https://raw.githubusercontent.com/Joomla-Bible-Study/CWMLivingWord/main/build/livingword-changelog.xml"


### PR DESCRIPTION
Closes #99. Last item before cutting 5.6.0.

## Why now

`cwm-changelog` derives the Joomla changelog entry from the GitHub release body. Ours have been install instructions, so generation produced entries listing system requirements as though they were changes:

```xml
<note>
    <item>PHP 8.3+</item>
    <item>Joomla 5.x / 6.x</item>
</note>
```

That is why 5.0.0–5.5.0 had to be hand-written in #88.

It matters from this release on: the `<changelogurl>` added in #88 means Joomla shows a **Changelog tab** when the update is offered, and ARS republishes the same text on the download page — the only changelog a site administrator following an update link ever sees.

## Change

Configures `release.notesFile`, so hand-written notes lead the release body with the generated pull-request list kept beneath, and adds `build/release-notes-5.6.0.md`.

Written for the person deciding whether to update rather than for us — and using the headings the parser recognises, so the same file serves both audiences. Simulating the parser against it:

```
<fix>:      5 item(s)
<addition>: 2 item(s)
<note>:     3 item(s)
```

A real changelog entry rather than boilerplate.

## On the content

The notes lead with the install fix rather than the features, because that is the honest headline: every release before 5.6.0-beta2 shipped a package Joomla refused to install. Anyone who tried LivingWord and failed deserves to see that named, not buried under a feature list.

They also tell beta testers explicitly that the missing index and the disabled task plugin are repaired automatically on update, so nobody goes looking for something to do by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)