### PR TITLE
chore(deps): update cwm/build-tools to v1.13.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.13.1",
+            "version": "v1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "45301cfbb189e69298ab30cf9800ca76d507e28d"
+                "reference": "6b9f2ff7f7d4a301a1b1c9a1504eb5eec5ccf61e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/45301cfbb189e69298ab30cf9800ca76d507e28d",
-                "reference": "45301cfbb189e69298ab30cf9800ca76d507e28d",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/6b9f2ff7f7d4a301a1b1c9a1504eb5eec5ccf61e",
+                "reference": "6b9f2ff7f7d4a301a1b1c9a1504eb5eec5ccf61e",
                 "shasum": ""
             },
             "require": {
@@ -401,10 +401,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.13.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.13.2",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-07-30T20:37:58+00:00"
+            "time": "2026-07-30T22:38:58+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Picks up [v1.13.2](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.13.2), which unblocks the 5.6.0 release.

`cwm-release` died at step 4 with `nothing to commit` — the version was already bumped to 5.6.0 in #102 so the upgrade test had something newer than the last release to run against, which left the tree with no diff for the bump commit. `set -e` then took the release down after the build had run and before anything was tagged.

Lock only; the `^1.13` constraint already permitted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)