### PR TITLE
feat(compat): declare Joomla 7 in the manifests

### DIFF
--- a/livingword.xml
+++ b/livingword.xml
@@ -15,6 +15,7 @@
         <cms>
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
+            <targetplatform name="joomla" version="7[.0-9]" />
         </cms>
         <php minimum="8.3.0" />
     </compatibility>

--- a/mod_livingword/mod_livingword.xml
+++ b/mod_livingword/mod_livingword.xml
@@ -15,6 +15,7 @@
         <cms>
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
+            <targetplatform name="joomla" version="7[.0-9]" />
         </cms>
         <php minimum="8.3.0" />
     </compatibility>

--- a/plg_task_livingword/livingword.xml
+++ b/plg_task_livingword/livingword.xml
@@ -15,6 +15,7 @@
         <cms>
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
+            <targetplatform name="joomla" version="7[.0-9]" />
         </cms>
         <php minimum="8.3.0" />
     </compatibility>


### PR DESCRIPTION
Refs #97. Does the code half; the ARS half needs the admin UI.

## Tested before declared

The issue's checklist put "actually test against j70-dev" last. It should gate the rest, so I ran it first — using the **published** `pkg_livingword-5.6.0.zip`, not a local build, against j70-dev (Joomla **7.0.0-alpha1-dev**, PHP 8.4.17):

| Check | Result |
|---|---|
| Package installs | ✅ `[OK] CWM LivingWord 5.6.0 has been installed successfully` |
| Extensions registered | ✅ component, module, package, plugin — all at 5.6.0 |
| Task plugin auto-enabled | ✅ install script works on 7.x as on 5.x/6.x |
| Schema | ✅ 9 tables created |
| Seeded menu + SEF routing | ✅ resolves to `/index.php/livingword-home` |
| Site view renders | ✅ HTTP 200, 16 LivingWord references, no PHP errors |

So install, routing and rendering all work. This is not a paper declaration.

## Why declaring now is safe despite 7.0 being alpha

`<targetplatform>` is **not enforced at install** — Joomla's installer never reads it (verified against `libraries/src/Installer/`). It affects what the *updater* offers, not what can be installed. And there are no Joomla 7 sites to offer anything to, because 7.0 hasn't shipped.

The risk of declaring early is therefore close to zero, and the risk of *not* declaring is that when 7.0 does ship, every J7 site is silently excluded from updates — exactly the failure this issue was filed about.

## Not done here

The ARS half:

- The update stream's platform filter still reads `((5)|(6))`
- `ars.environments` has no Joomla 7 id — currently `["45","46","48","49","50"]`

Neither is reachable from the API — `/v1/ars/updatestreams` and `/v1/ars/environments` both 404, since `plg_webservices_ars` routes neither. Both need the ARS admin UI, so #97 stays open for them.

That half is also not urgent: with no released Joomla 7, there is nothing for the stream to serve. It wants doing before 7.0 ships, not before this merges.

## Worth revisiting

7.0.0-alpha1-dev is a moving target. This says "installs and runs on 7.0 as it stands today", which is true and useful, but it should be re-verified when 7.0 reaches RC — and the install/upgrade gate now makes that cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)