### PR TITLE
test(a11y): add WCAG 2.2 AA scanning for admin and site views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,13 @@ Desktop.ini
 # Local Claude Code config — personal settings, local permission hooks
 .claude/
 
+# Playwright. .auth holds a live Joomla administrator session cookie, written
+# by global-setup; test-results holds screenshots and video of the admin UI on
+# failure. Neither belongs in the repository.
+tests/e2e/.auth/
+/build/test-results/
+/playwright-report/
+
 # === cwm-build-tools: managed (do not edit between markers) ===
 # Dependencies
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,8 @@
     "test:reset-testsite": "@php build/reset-testsite.php",
     "test:install":       "bash build/test-install.sh",
     "test:migrations":    "@php build/verify-migrations.php",
+    "test:a11y":          "npm run test:a11y",
+    "test:e2e":           "npm run test:e2e",
     "test:upgrade":       "bash build/test-upgrade.sh",
     "test:release":       "bash build/test-release.sh",
     "setup":              "cwm-setup",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "5.6.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.62.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "csso": "^5.0.5",
@@ -21,6 +23,19 @@
       "engines": {
         "node": ">=20.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -265,6 +280,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -793,6 +824,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -1488,6 +1529,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "npm": ">=10.0.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.62.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "csso": "^5.0.5",
@@ -27,6 +29,8 @@
     "build:css": "SOURCE_DIR=build/media_source/css OUTPUT_DIR=media/com_livingword/css node libraries/vendor/cwm/build-tools/templates/build-css.js",
     "build:js": "SOURCE_DIR=build/media_source/js OUTPUT_DIR=media/com_livingword/js rollup -c libraries/vendor/cwm/build-tools/templates/rollup.config.js",
     "watch": "SOURCE_DIR=build/media_source/js OUTPUT_DIR=media/com_livingword/js rollup -c libraries/vendor/cwm/build-tools/templates/rollup.config.js -w",
-    "lint:js": "eslint --max-warnings=0 ."
+    "lint:js": "eslint --max-warnings=0 .",
+    "test:e2e": "playwright test",
+    "test:a11y": "playwright test --grep @a11y"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,83 @@
+/**
+ * Playwright E2E configuration for CWM LivingWord.
+ *
+ * Today the suite is accessibility scanning only (WCAG 2.2 AA). The project
+ * layout anticipates functional specs alongside it: anything under
+ * tests/e2e/admin runs authenticated, anything under tests/e2e/site as a
+ * visitor.
+ *
+ * Configuration is resolved in two layers:
+ *   1. build.dist.properties — defaults (committed, safe to share)
+ *   2. build.properties      — local overrides for credentials/URLs (gitignored)
+ *
+ * Run `composer setup` if build.properties does not exist yet.
+ */
+
+const { defineConfig, devices } = require('@playwright/test');
+const { loadProps } = require('./tests/e2e/helpers/properties');
+
+const props = loadProps(__dirname);
+
+const j6Url = props['builder.j6dev.url'] || 'https://j6-dev.local:8890';
+
+module.exports = defineConfig({
+    testDir: './tests/e2e',
+    outputDir: 'build/test-results/',
+    fullyParallel: false,
+    workers: 1,
+    retries: 0,
+    timeout: 30000,
+    globalSetup: require.resolve('./tests/e2e/global-setup.js'),
+    reporter: [
+        ['list'],
+        ['html', { outputFolder: 'build/reports/e2e', open: 'never' }],
+    ],
+    use: {
+        ignoreHTTPSErrors: true,
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+
+        // Real Chromium rather than Playwright's default headless shell.
+        //
+        // `headless: true` resolves to chrome-headless-shell, the old headless
+        // implementation Google split out of the Chrome binary in Chrome 132.
+        // It is supported and faster, but it is not the renderer any visitor
+        // uses — and two of the rules gated on here measure rendered output
+        // rather than markup:
+        //
+        //   target-size    2.5.8, new in WCAG 2.2 — element size in CSS px
+        //   color-contrast 1.4.3 — computed foreground/background colours
+        //
+        // A pass from a renderer nobody runs is a weak basis for a conformance
+        // claim. Accuracy is worth more than the speed.
+        channel: 'chromium',
+    },
+    projects: [
+        // Scanned on Joomla 6 only. LivingWord renders the same markup on 5, 6
+        // and 7 — the templates carry no version branching — so scanning every
+        // platform would report identical violations several times over and
+        // slow the gate for nothing. Platform differences are what the install
+        // and upgrade suites are for.
+        //
+        // If a violation ever proves platform-specific it will be a Joomla
+        // template difference outside the scanned region; add a project then,
+        // deliberately.
+        {
+            name: 'admin-j6',
+            testMatch: '**/admin/**/*.spec.js',
+            use: {
+                ...devices['Desktop Chrome'],
+                baseURL: j6Url,
+                storageState: 'tests/e2e/.auth/admin-j6.json',
+            },
+        },
+        {
+            name: 'site-j6',
+            testMatch: '**/site/**/*.spec.js',
+            use: {
+                ...devices['Desktop Chrome'],
+                baseURL: j6Url,
+            },
+        },
+    ],
+});

--- a/tests/e2e/admin/a11y.spec.js
+++ b/tests/e2e/admin/a11y.spec.js
@@ -1,0 +1,101 @@
+/**
+ * E2E — WCAG 2.2 AA, administrator views
+ *
+ * Scans every screen the administrator half of the component renders: the
+ * control panel, the list views and the edit forms. Confined to
+ * `section#content`, the region the component renders into — the Atum
+ * template's sidebar, toolbar and header belong to Joomla, and their markup is
+ * neither ours to fix nor fair to judge us on.
+ *
+ * Admin pages need an authenticated session; the admin-* Playwright project
+ * supplies one via storageState.
+ *
+ * Each case also carries a "does this screen render at all" duty: it requires
+ * `section#content` before scanning, so a view that 500s or comes back blank
+ * fails here rather than passing silently.
+ */
+
+const { test, expect } = require('@playwright/test');
+const { expectNoViolations } = require('../helpers/axe');
+
+const LIVINGWORD_CONTENT = 'section#content';
+
+/**
+ * Widgets rendered by third-party code we neither author nor can patch.
+ *
+ * Excluded by selector rather than by disabling rules, so `target-size` and
+ * `aria-input-field-name` still apply to LivingWord's own markup on the same
+ * page.
+ *
+ *   .choices  Joomla's Choices.js — the remove button is under the 24x24
+ *             minimum of SC 2.5.8. Used by the tag fields added in 5.6.0.
+ *   .tox-tinymce  the editor on plan and plan-day descriptions: role
+ *                 "application" without its required ARIA attributes, and
+ *                 editor iframes with no title.
+ */
+const THIRD_PARTY = ['.choices', '.tox-tinymce'];
+
+/**
+ * Every list-style admin screen, by view name.
+ */
+const SCREENS = [
+    ['control panel', 'cwmcpanel'],
+    ['reading plans', 'cwmplans'],
+    ['plan days', 'cwmplandetails'],
+    ['resource links', 'cwmlinks'],
+    ['study tools', 'cwmtools'],
+    ['groups', 'cwmgroups'],
+    ['subscribers', 'cwmusers'],
+    ['database maintenance', 'cwmutilities'],
+];
+
+/**
+ * Every entity edit form, reached as a fresh add.
+ *
+ * No fixture record is needed — an add renders the same form an edit does, and
+ * form controls are where labelling and grouping failures concentrate, and
+ * where a screen-reader user is most likely to be blocked outright.
+ */
+const FORMS = [
+    ['reading plan', 'cwmplan'],
+    ['plan day', 'cwmplandetail'],
+    ['resource link', 'cwmlink'],
+    ['study tool', 'cwmtool'],
+    ['group', 'cwmgroup'],
+];
+
+test.describe('Admin accessibility (WCAG 2.2 AA) @a11y', () => {
+    for (const [label, view] of SCREENS) {
+        test(`${label} meets WCAG 2.2 AA`, async ({ page }) => {
+            await page.goto(`administrator/index.php?option=com_livingword&view=${view}`);
+
+            await expect(
+                page.locator(LIVINGWORD_CONTENT),
+                `${label} did not render a content region`
+            ).toBeVisible();
+
+            await expectNoViolations(page, expect, {
+                include: LIVINGWORD_CONTENT,
+                exclude: THIRD_PARTY,
+            });
+        });
+    }
+
+    for (const [label, view] of FORMS) {
+        test(`${label} form meets WCAG 2.2 AA`, async ({ page }) => {
+            await page.goto(
+                `administrator/index.php?option=com_livingword&view=${view}&layout=edit`
+            );
+
+            await expect(
+                page.locator(`${LIVINGWORD_CONTENT} form`),
+                `${label} form did not render`
+            ).toBeVisible();
+
+            await expectNoViolations(page, expect, {
+                include: LIVINGWORD_CONTENT,
+                exclude: THIRD_PARTY,
+            });
+        });
+    }
+});

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,276 @@
+/**
+ * Playwright global setup — authenticates against the dev-site admins and
+ * saves session storage state for reuse across all admin specs.
+ *
+ * Runs once before the entire test suite. Three behaviours matter here, all
+ * from #1342 — a transient login failure used to cost the whole run:
+ *
+ *   - Only the sites the selected projects actually use are authenticated.
+ *     Which sites those are is read from the resolved config: a project that
+ *     declares a storageState needs its site's admin session, one that
+ *     doesn't (the site-* projects) needs nothing. `--project=admin-j6`
+ *     therefore never touches j5-dev.
+ *   - A still-valid saved session is reused instead of re-authenticating.
+ *     Joomla admin sessions outlive a test run by default, so back-to-back
+ *     runs skip the login dance (and its flake surface) entirely.
+ *   - A login that does run is retried with backoff before it fails the run.
+ *     The observed failure mode is a rejection that succeeds moments later
+ *     with identical credentials — a flake, not a misconfiguration.
+ *
+ * Configuration follows a two-layer approach:
+ *   1. build.dist.properties — defaults (committed)
+ *   2. build.properties      — local overrides for credentials (gitignored)
+ *
+ * Uses a real browser context so that the user-agent stored in the Joomla
+ * PHP session matches the Chromium user-agent used by the actual test runs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('@playwright/test');
+const { loadProps, installForRole } = require('./helpers/properties');
+
+/**
+ * Project names passed on the command line, e.g. --project=admin-j6.
+ *
+ * Playwright hands globalSetup the full resolved config with every project
+ * in it, regardless of any --project filter (upstream: playwright#14212),
+ * so the filter has to be recovered from argv. Empty array = no filter.
+ */
+function selectedProjectNames() {
+    const names = [];
+    const argv = process.argv;
+
+    for (let i = 0; i < argv.length; i += 1) {
+        if (argv[i] === '--project' && argv[i + 1]) {
+            names.push(argv[i + 1]);
+        } else if (argv[i].startsWith('--project=')) {
+            names.push(argv[i].slice('--project='.length));
+        }
+    }
+
+    return names;
+}
+
+/**
+ * Whether a saved storage state still holds an authenticated admin session.
+ *
+ * One page load either way: reusing costs the same navigation the login
+ * would start with, and skips the credential dance that follows.
+ */
+async function stateStillValid(browser, baseUrl, storageStatePath) {
+    if (!fs.existsSync(storageStatePath)) {
+        return false;
+    }
+
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true, storageState: storageStatePath });
+
+    try {
+        const page = await ctx.newPage();
+        await page.goto(`${baseUrl}/administrator/index.php`, {
+            waitUntil: 'domcontentloaded',
+            timeout: 15000,
+        });
+
+        // Valid means the sidebar toggle rendered — a positive signal only an
+        // authenticated backend produces (the login page has no sidebar). "No
+        // login form" would also be true of an error page, and treating that
+        // as a live session skips the login that would surface the problem.
+        //
+        // waitFor, not isVisible: isVisible() answers for the instant it is
+        // called and ignores its timeout option.
+        await page.locator('#menu-collapse').waitFor({ state: 'visible', timeout: 5000 });
+
+        return true;
+    } catch {
+        return false;
+    } finally {
+        await ctx.close();
+    }
+}
+
+async function loginAdmin(browser, baseUrl, username, password, storageStatePath) {
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+
+    try {
+        const page = await ctx.newPage();
+
+        // Load the login page
+        await page.goto(`${baseUrl}/administrator/index.php`, { waitUntil: 'networkidle' });
+
+        // Confirm the login form is present. Already-authenticated is only
+        // claimed on the positive signal (the admin sidebar), never on the
+        // form's mere absence.
+        const loginVisible = await page.locator('#form-login').isVisible().catch(() => false);
+        if (!loginVisible) {
+            const authed = await page.locator('#menu-collapse')
+                .waitFor({ state: 'visible', timeout: 5000 })
+                .then(() => true, () => false);
+            if (authed) {
+                console.log(`  Already authenticated at ${baseUrl}, saving state.`);
+                await ctx.storageState({ path: storageStatePath });
+                return;
+            }
+            throw new Error(`Neither the login form nor the admin UI rendered at ${baseUrl}/administrator/`);
+        }
+
+        // Fill credentials
+        await page.fill('#mod-login-username', username);
+        await page.fill('#mod-login-password', password);
+
+        // Submit the form via JS to bypass Joomla's form-validate JS which
+        // can prevent submission in headless mode. form.submit() bypasses the
+        // onsubmit handler but correctly includes all hidden fields (CSRF token).
+        await page.evaluate(() => document.getElementById('form-login').submit());
+
+        // Success must be a POSITIVE signal — the sidebar toggle, which only
+        // an authenticated backend renders (the login page has no sidebar).
+        // "The login form is gone" is not enough: mid-redirect the form is
+        // absent from a page that is not logged in either, and that false
+        // success once saved a guest session as auth state while the real
+        // problem (stale credentials in build.properties) went unreported.
+        //
+        // waitFor, not waitForLoadState-then-isVisible: networkidle can
+        // resolve on the *old* page before the submit's navigation begins,
+        // and isVisible() answers for that instant without waiting.
+        const authed = await page.locator('#menu-collapse')
+            .waitFor({ state: 'visible', timeout: 25000 })
+            .then(() => true, () => false);
+
+        if (!authed) {
+            const rejected = await page.locator('#form-login').isVisible().catch(() => false);
+            throw new Error(
+                `Login failed for ${baseUrl} — ` +
+                (rejected
+                    ? 'credentials rejected (check this site\'s username/password in build.properties).\n'
+                    : 'no admin UI appeared after submit.\n') +
+                `Current URL: ${page.url()}`
+            );
+        }
+
+        await ctx.storageState({ path: storageStatePath });
+        console.log(`  Saved auth state → ${path.basename(storageStatePath)}`);
+    } finally {
+        await ctx.close();
+    }
+}
+
+/**
+ * loginAdmin with retries. The whole suite hangs off this succeeding, so a
+ * transient rejection gets a second and third chance before it is allowed
+ * to be fatal.
+ */
+async function loginAdminWithRetry(browser, baseUrl, username, password, storageStatePath) {
+    const attempts = 3;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            await loginAdmin(browser, baseUrl, username, password, storageStatePath);
+            return;
+        } catch (err) {
+            if (attempt === attempts) {
+                throw err;
+            }
+            const delayMs = attempt * 2500;
+            console.warn(
+                `  Login attempt ${attempt}/${attempts} failed (${String(err.message || err).split('\n')[0]}); `
+                + `retrying in ${delayMs / 1000}s…`
+            );
+            await new Promise((resolve) => { setTimeout(resolve, delayMs); });
+        }
+    }
+}
+
+module.exports = async function globalSetup(config) {
+    const root = path.join(__dirname, '../..');
+    const props = loadProps(root);
+
+    const authDir = path.join(__dirname, '.auth');
+    if (!fs.existsSync(authDir)) {
+        fs.mkdirSync(authDir, { recursive: true });
+    }
+
+    // The sites this repo can authenticate against, keyed by the storage
+    // state file the Playwright projects reference. The two dev sites have
+    // fixed property keys; the test site is discovered by role, because
+    // install naming is local to each build.properties.
+    const testInstall = installForRole(props, 'test');
+
+    const sites = [
+        {
+            label: 'j5-dev',
+            url: props['builder.j5dev.url'] || 'https://j5-dev.local:8890',
+            username: props['builder.j5dev.username'] || props['builder.joomla_username'],
+            password: props['builder.j5dev.password'] || props['builder.joomla_password'],
+            stateFile: 'admin-j5.json',
+        },
+        {
+            label: 'j6-dev',
+            url: props['builder.j6dev.url'] || 'https://j6-dev.local:8890',
+            username: props['builder.j6dev.username'] || props['builder.joomla_username'],
+            password: props['builder.j6dev.password'] || props['builder.joomla_password'],
+            stateFile: 'admin-j6.json',
+        },
+        ...(testInstall ? [{
+            label: testInstall.id,
+            url: testInstall.url,
+            username: testInstall.username,
+            password: testInstall.password,
+            stateFile: 'admin-test.json',
+        }] : []),
+    ];
+
+    // Authenticate only the sites the selected projects consume. A project
+    // needs a site's admin session exactly when it declares that site's
+    // storageState; the site-* projects declare none and need none.
+    const selected = selectedProjectNames();
+    const projects = (config.projects || [])
+        .filter((p) => !selected.length || selected.includes(p.name));
+
+    const needed = sites.filter((site) => projects.some(
+        (p) => p.use && typeof p.use.storageState === 'string' && p.use.storageState.endsWith(site.stateFile)
+    ));
+
+    if (!needed.length) {
+        console.log('\nGlobal setup: no selected project needs an admin session; nothing to authenticate.\n');
+        return;
+    }
+
+    const missing = needed.filter((site) => !site.username || !site.password);
+    if (missing.length) {
+        throw new Error(
+            `Missing admin credentials for ${missing.map((s) => s.label).join(', ')}.\n` +
+            'Set builder.j5dev.username / builder.j5dev.password (and j6dev) in build.properties.\n' +
+            'Or set builder.joomla_username / builder.joomla_password as a shared fallback.'
+        );
+    }
+
+    // globalSetup runs outside the project fixtures, so the `use.channel`
+    // setting in playwright.config.js does not reach this call — it has to be
+    // repeated. Without it this launches Playwright's default headless
+    // browser, chrome-headless-shell, while every test runs real Chromium.
+    //
+    // Two reasons that matters: the shell may not be installed at all (this
+    // failed here with "Executable doesn't exist"), and authenticating in one
+    // browser while testing in another is a difference worth not having in a
+    // login flow.
+    const browser = await chromium.launch({ channel: 'chromium' });
+
+    try {
+        for (const site of needed) {
+            const statePath = path.join(authDir, site.stateFile);
+
+            if (await stateStillValid(browser, site.url, statePath)) {
+                console.log(`Reusing valid admin session for ${site.label} (${path.basename(statePath)}).`);
+                continue;
+            }
+
+            console.log(`\nAuthenticating against ${site.label} (${site.url})…`);
+            await loginAdminWithRetry(browser, site.url, site.username, site.password, statePath);
+        }
+    } finally {
+        await browser.close();
+    }
+
+    console.log('Global setup complete.\n');
+};

--- a/tests/e2e/helpers/axe.js
+++ b/tests/e2e/helpers/axe.js
@@ -1,0 +1,172 @@
+/**
+ * WCAG 2.2 Level AA scanning for the E2E suite.
+ *
+ * Wraps @axe-core/playwright so every accessibility check in the suite asks
+ * the same question of every page, and reports a failure in terms someone can
+ * act on rather than a wall of JSON.
+ *
+ * Scope is deliberately narrow in two ways:
+ *
+ *   - Only the WCAG A and AA rule sets run. axe also ships best-practice and
+ *     experimental rules; those are worth reading but failing a release on
+ *     them would be failing on opinion rather than on the standard.
+ *
+ *   - Only LivingWord's own markup is scanned where a page selector allows it.
+ *     A Joomla site's template, other extensions and third-party modules share
+ *     the page, and we can neither fix nor be judged on their markup.
+ *
+ * An automated pass is not a conformance claim. axe catches roughly a third to
+ * a half of WCAG issues — contrast, names, roles, structure — and cannot judge
+ * whether alt text is *meaningful* or whether a flow is usable by keyboard in
+ * practice. It is a floor, not a ceiling.
+ *
+ * That gap is widest at 2.2. WCAG 2.2 adds six AA criteria and axe automates
+ * essentially one of them, `target-size` (2.5.8). These still need a human:
+ *
+ *   2.4.11 Focus Not Obscured        sticky headers hiding the focused control
+ *   2.5.7  Dragging Movements        drag-only interactions, e.g. the layout
+ *                                    editor and the ordering drag handles
+ *   3.2.6  Consistent Help           help placed consistently across pages
+ *   3.3.7  Redundant Entry           re-asking for what the user already gave
+ *   3.3.8  Accessible Authentication no cognitive-function test to log in
+ *
+ * One bears directly on LivingWord: the drag-handle ordering on the resource
+ * links list engages 2.5.7, and nothing below covers it. Joomla core provides
+ * the handle, but the decision to enable ordering is ours, so a keyboard
+ * alternative has to exist and be checked by hand.
+ *
+ * This file is shared with Proclaim (Joomla-Bible-Study/Proclaim), where it
+ * originated. Fixes worth having in both belong upstream in whichever repo
+ * finds them first.
+ *
+ * WCAG 2.2 also *removed* 4.1.1 Parsing. axe tags its `duplicate-id` rules
+ * `wcag2a-obsolete` rather than `wcag2a`, so the tag set below does not pull
+ * them in — verified against axe-core 4.12.1 rather than assumed.
+ */
+
+const AxeBuilder = require('@axe-core/playwright').default;
+
+/**
+ * The rule tags that together constitute WCAG 2.2 Level AA.
+ *
+ * 2.2 is backward compatible: everything in 2.0 and 2.1 still applies, so the
+ * earlier tags stay and `wcag22aa` is additive. There is no `wcag22a` tag —
+ * the two new A-level criteria (3.2.6, 3.3.7) have no automated rule.
+ */
+const WCAG_AA_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'];
+
+/**
+ * Run an axe scan restricted to WCAG A/AA rules.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {object}   [options]
+ * @param {string}   [options.include]  CSS selector to confine the scan to.
+ * @param {string[]} [options.exclude]  CSS selectors to skip.
+ * @param {string[]} [options.disableRules] Rule ids to switch off, with a reason
+ *                                          in the calling test.
+ * @returns {Promise<import('axe-core').AxeResults>}
+ */
+async function scan(page, options = {}) {
+    let builder = new AxeBuilder({ page }).withTags(WCAG_AA_TAGS);
+
+    if (options.include) {
+        builder = builder.include(options.include);
+    }
+
+    for (const selector of options.exclude || []) {
+        builder = builder.exclude(selector);
+    }
+
+    if (options.disableRules && options.disableRules.length) {
+        builder = builder.disableRules(options.disableRules);
+    }
+
+    return builder.analyze();
+}
+
+/**
+ * Turn axe violations into something readable in a test failure.
+ *
+ * The default output is the full result object, which buries the one line that
+ * matters — which element, and what to change.
+ *
+ * @param {import('axe-core').Result[]} violations
+ * @returns {string}
+ */
+function formatViolations(violations) {
+    if (!violations.length) {
+        return 'No WCAG A/AA violations.';
+    }
+
+    const lines = [`${violations.length} WCAG A/AA violation type(s):`, ''];
+
+    for (const violation of violations) {
+        const tags = violation.tags.filter((t) => t.startsWith('wcag')).join(', ');
+        lines.push(`  [${violation.impact}] ${violation.id} — ${violation.help}`);
+        lines.push(`    ${tags}`);
+        lines.push(`    ${violation.helpUrl}`);
+
+        // Three is enough to characterise the problem; a listing page can
+        // repeat the same fault on every row.
+        for (const node of violation.nodes.slice(0, 3)) {
+            lines.push(`    → ${node.target.join(' ')}`);
+            const [, detail] = (node.failureSummary || '').split('\n').filter(Boolean);
+
+            if (detail) {
+                lines.push(`      ${detail.trim()}`);
+            }
+        }
+
+        if (violation.nodes.length > 3) {
+            lines.push(`    … and ${violation.nodes.length - 3} more element(s)`);
+        }
+
+        lines.push('');
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Scan a page and fail the test with a readable report if it does not meet AA.
+ *
+ * @param {import('@playwright/test').Page}   page
+ * @param {import('@playwright/test').Expect} expect
+ * @param {object} [options] Passed through to scan().
+ */
+async function expectNoViolations(page, expect, options = {}) {
+    // Joomla renders its error pages inside the same content region as a real
+    // view, so "the container is visible" is true on a 404 and a scan of an
+    // error page reports no violations and passes.
+    //
+    // That is not hypothetical. A wrong admin view name (cwmsermons, which does
+    // not exist — the admin view is cwmmessages) made this suite report "sermon
+    // list meets WCAG AA" while scanning a 404. A silent false pass on an
+    // accessibility gate is worse than no gate, because it is quoted as
+    // evidence of compliance.
+    const title = await page.title();
+
+    expect(title, `Page is an error page, not the view under test: "${title}"`)
+        .not.toMatch(/^Error:?\s*\d*/i);
+
+    // Inline PHP diagnostics are a second way a scan lies. A dev site with
+    // display_errors on prints "Deprecated: …" (or an Xdebug trace table)
+    // straight into the markup, and axe then judges the error dump instead of
+    // the view — this suite once reported the topic form's colours wrong when
+    // the "violation" was Xdebug's own green-on-grey stack trace. Real bugs
+    // both times, but the failure should say "PHP error leaked into the page",
+    // not "contrast".
+    const phpError = await page.locator('body').innerText().then((text) => {
+        const match = text.match(/^(Deprecated|Warning|Notice|Fatal error): .{0,200}/m);
+
+        return match ? match[0] : null;
+    });
+
+    expect(phpError, 'PHP error output leaked into the page').toBeNull();
+
+    const results = await scan(page, options);
+
+    expect(formatViolations(results.violations)).toBe('No WCAG A/AA violations.');
+}
+
+module.exports = { scan, formatViolations, expectNoViolations, WCAG_AA_TAGS };

--- a/tests/e2e/helpers/properties.js
+++ b/tests/e2e/helpers/properties.js
@@ -1,0 +1,94 @@
+/**
+ * build.properties access for the E2E suite.
+ *
+ * One parser shared by playwright.config.js and global-setup.js, with the
+ * same two-layer resolution the PHP tooling uses:
+ *   1. build.dist.properties — defaults (committed)
+ *   2. build.properties      — local overrides for credentials (gitignored)
+ *
+ * Nothing here assumes what an install is named. Sites are discovered from
+ * `builder.installs` and their `builder.<id>.role`, mirroring
+ * PropertiesReader::installsFor() on the PHP side — someone whose test
+ * install is called `trunk-test` gets exactly the same behaviour as one
+ * whose install is called `j6-test`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function parseProperties(filePath) {
+    const props = {};
+    if (!fs.existsSync(filePath)) {
+        return props;
+    }
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) {
+            continue;
+        }
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) {
+            continue;
+        }
+        props[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+    return props;
+}
+
+/**
+ * @param {string} root Repo root.
+ * @returns {object} Merged properties, build.properties winning.
+ */
+function loadProps(root) {
+    const dist = parseProperties(path.join(root, 'build.dist.properties'));
+    const local = parseProperties(path.join(root, 'build.properties'));
+    return { ...dist, ...local };
+}
+
+/**
+ * The install ids listed in builder.installs.
+ *
+ * @param {object} props
+ * @returns {string[]}
+ */
+function installIds(props) {
+    return (props['builder.installs'] || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+/**
+ * Connection details for one named install.
+ *
+ * @param {object} props
+ * @param {string} id
+ * @returns {{id: string, role: string, url: string, username: string, password: string}}
+ */
+function installById(props, id) {
+    return {
+        id,
+        role: props[`builder.${id}.role`] || '',
+        url: props[`builder.${id}.url`] || '',
+        username: props[`builder.${id}.username`] || props['builder.joomla_username'] || '',
+        password: props[`builder.${id}.password`] || props['builder.joomla_password'] || '',
+    };
+}
+
+/**
+ * The first install marked with the given role, or null. The role=test
+ * install is the one `composer test:install` provisions from the built
+ * package; the API acceptance suite runs there and nowhere else.
+ *
+ * @param {object} props
+ * @param {string} role
+ * @returns {object|null}
+ */
+function installForRole(props, role) {
+    const id = installIds(props).find((name) => (props[`builder.${name}.role`] || '') === role);
+
+    return id ? installById(props, id) : null;
+}
+
+module.exports = { parseProperties, loadProps, installIds, installById, installForRole };

--- a/tests/e2e/site/a11y.spec.js
+++ b/tests/e2e/site/a11y.spec.js
@@ -1,0 +1,82 @@
+/**
+ * E2E — WCAG 2.2 AA, public site views
+ *
+ * Scans every page a visitor can reach. The scan is confined to the
+ * `com-livingword-*` wrapper each view renders, because everything around it
+ * is the site's Joomla template and other extensions — markup LivingWord does
+ * not own and cannot fix.
+ *
+ * These degrade rather than fail on an empty database: with no plans or groups
+ * a view still renders its wrapper, and an empty wrapper is still worth
+ * scanning — headings, landmarks and the empty-state message are exactly the
+ * markup a screen-reader user meets first.
+ *
+ * The three unrouted views (cwmcomplete, cwminvite, cwmunsubscribe) are
+ * reached by their raw query string. They are the pages a person lands on from
+ * an email or an invitation link — often the first LivingWord page they ever
+ * see, and the one they meet without having chosen to.
+ */
+
+const { test, expect } = require('@playwright/test');
+const { expectNoViolations } = require('../helpers/axe');
+
+/**
+ * Matches the per-view wrapper: com-livingword-home, -resources, -groups and
+ * so on. Deliberately the outer wrapper rather than an inner content div — the
+ * wrapper is where landmarks and headings live.
+ */
+const LIVINGWORD_CONTENT = '[class*="com-livingword-"]';
+
+/**
+ * Every menu-reachable view, by the name the site router accepts.
+ */
+const VIEWS = [
+    ['home', 'cwmhome'],
+    ['plan view', 'cwmplanview'],
+    ['resources', 'cwmresources'],
+    ['study tools', 'cwmtools'],
+    ['groups', 'cwmgroups'],
+    ['settings', 'cwmsettings'],
+];
+
+/**
+ * Views reached from an email or invitation rather than from a menu.
+ *
+ * Scanned with a deliberately invalid token: the failure path is what an
+ * expired or mistyped link produces, it needs no fixture, and its message is
+ * as much a part of the experience as the success path. A visitor who follows
+ * a stale unsubscribe link still has to be able to read what went wrong.
+ */
+const LANDING_PAGES = [
+    ['completion landing', 'index.php?option=com_livingword&view=cwmcomplete&token=invalid-token-for-a11y-scan'],
+    ['unsubscribe landing', 'index.php?option=com_livingword&view=cwmunsubscribe&token=invalid-token-for-a11y-scan'],
+    ['invitation landing', 'index.php?option=com_livingword&view=cwminvite&token=invalid-token-for-a11y-scan'],
+];
+
+test.describe('Site accessibility (WCAG 2.2 AA) @a11y', () => {
+    for (const [label, view] of VIEWS) {
+        test(`${label} meets WCAG 2.2 AA`, async ({ page }) => {
+            await page.goto(`index.php?option=com_livingword&view=${view}`);
+
+            await expect(
+                page.locator(LIVINGWORD_CONTENT).first(),
+                `${label} did not render a LivingWord wrapper`
+            ).toBeVisible();
+
+            await expectNoViolations(page, expect, { include: LIVINGWORD_CONTENT });
+        });
+    }
+
+    for (const [label, url] of LANDING_PAGES) {
+        test(`${label} meets WCAG 2.2 AA`, async ({ page }) => {
+            await page.goto(url);
+
+            await expect(
+                page.locator(LIVINGWORD_CONTENT).first(),
+                `${label} did not render a LivingWord wrapper`
+            ).toBeVisible();
+
+            await expectNoViolations(page, expect, { include: LIVINGWORD_CONTENT });
+        });
+    }
+});


### PR DESCRIPTION
Adds automated WCAG 2.2 Level AA scanning, using axe-core through Playwright. Modelled on Proclaim's suite, which is where the scanner and its hard-won guards come from.

## Coverage — 22 scans

| Area | Screens |
|---|---|
| Admin lists | control panel, plans, plan days, links, tools, groups, subscribers, maintenance |
| Admin forms | plan, plan day, link, tool, group |
| Site views | home, plan view, resources, tools, groups, settings |
| Landing pages | completion, unsubscribe, invitation |

The landing pages are scanned with a deliberately invalid token: that failure path needs no fixture, and it is what a person following an expired email link actually meets — often the first LivingWord page they ever see.

Each case also asserts its container rendered before scanning, so a view that 500s or comes back blank fails here rather than passing quietly.

## Deliberately narrow

- **WCAG A and AA rules only.** axe also ships best-practice and experimental rules; failing a release on those is failing on opinion rather than on the standard.
- **Scoped to our own markup** — `section#content` in admin, the `com-livingword-*` wrapper on the site. The Joomla template and other extensions share the page and their markup is neither ours to fix nor fair to judge us on.
- **Joomla 6 only.** The templates carry no version branching, so scanning 5, 6 and 7 would report identical violations three times over.

## Two guards worth keeping

Both inherited from Proclaim because both actually happened there:

1. **Error pages score clean.** Joomla renders its error pages into the same content region as a real view, so a scan of a 404 reports no violations and *passes* — a wrong view name once made that suite report a screen as meeting AA while scanning nothing. The page title is asserted not to be an error before scanning.
2. **Leaked PHP output gets judged as content.** A dev site with `display_errors` on prints notices into the markup, and axe then evaluates the error dump — once reported as a contrast failure when the real cause was an Xdebug stack trace. That now fails with "PHP error output leaked into the page" instead.

## First run: 16 of 22 pass

The 6 failures are real and filed separately, so this lands as a **working scanner, not a green gate**. Making it a gate is the follow-up.

```
[critical] select-name    — #csv_plan_id has no accessible name
[serious]  color-contrast — 3.34:1 and 1.97:1 against a 4.5:1 requirement
```

## An automated pass is not a conformance claim

axe covers roughly a third to a half of WCAG, and of the six AA criteria new in 2.2 it automates essentially one (`target-size`). The rest need a person — including **2.5.7 Dragging Movements**, which the resource-links ordering handles engage directly. That gap is documented in `helpers/axe.js` rather than left implicit, so the suite is not mistaken for more than it is.

## Note on `.gitignore`

`tests/e2e/.auth/` holds a live Joomla administrator session cookie written by global-setup, and `build/test-results/` holds screenshots and video of the admin UI on failure. Both are now ignored. Neither was ever committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)