### PR TITLE
fix(test): distinguish a not-applicable phase from a failed one

### DIFF
--- a/build/test-release.sh
+++ b/build/test-release.sh
@@ -18,26 +18,54 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 FAILED=()
+SKIPPED=()
+
+# Exit 3 from a phase means "not applicable here", not "passed" and not
+# "failed" — see the note in test-upgrade.sh. Reported loudly at the end so a
+# skipped phase can never be mistaken for a green one.
+run_phase() {
+    local label="$1"
+    shift
+
+    "$@"
+    local status=$?
+
+    if [ "$status" -eq 0 ]; then
+        return 0
+    fi
+
+    if [ "$status" -eq 3 ]; then
+        SKIPPED+=("$label")
+
+        return 0
+    fi
+
+    FAILED+=("$label")
+}
 
 echo "########################################################################"
 echo "# 1/3  CLEAN INSTALL"
 echo "########################################################################"
-bash build/test-install.sh || FAILED+=("clean install")
+run_phase "clean install" bash build/test-install.sh
 
 echo
 echo "########################################################################"
 echo "# 2/3  UPGRADE FROM LAST RELEASE"
 echo "########################################################################"
-bash build/test-upgrade.sh || FAILED+=("upgrade")
+run_phase "upgrade" bash build/test-upgrade.sh
 
 echo
 echo "########################################################################"
 echo "# 3/3  ACCESSIBILITY (WCAG 2.2 AA)"
 echo "########################################################################"
-npm run --silent test:a11y || FAILED+=("accessibility")
+run_phase "accessibility" npm run --silent test:a11y
 
 echo
 echo "========================================================================"
+
+for s in "${SKIPPED[@]:-}"; do
+    [ -n "$s" ] && echo " SKIPPED (not applicable): ${s}"
+done
 
 if [ ${#FAILED[@]} -gt 0 ]; then
     echo " RELEASE GATE FAILED:"
@@ -48,5 +76,10 @@ if [ ${#FAILED[@]} -gt 0 ]; then
     exit 1
 fi
 
-echo " RELEASE GATE PASSED — clean install and upgrade both verified."
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+    echo " RELEASE GATE PASSED — with the phase(s) above not applicable."
+else
+    echo " RELEASE GATE PASSED — install, upgrade and accessibility all verified."
+fi
+
 echo "========================================================================"

--- a/build/test-upgrade.sh
+++ b/build/test-upgrade.sh
@@ -36,12 +36,22 @@ if [ -z "$NEWVER" ] || [ -z "$BASEVER" ]; then
     exit 1
 fi
 
+# Exit 3 means "not applicable", as distinct from "failed". Immediately after a
+# release the active-development version IS the last release, so there is
+# nothing newer to upgrade to and the update() path cannot fire. That is not a
+# defect, and failing the release gate for it would leave the gate red between
+# every release and the next bump — which teaches people to ignore it.
+#
+# test-release.sh maps 3 to a loud SKIPPED. It stays loud deliberately: a
+# silently skipped phase reads as a pass, which is how an ungated release
+# happens.
 if [ "$NEWVER" = "$BASEVER" ]; then
-    echo "ERROR: active-development version ($NEWVER) equals the baseline ($BASEVER)." >&2
-    echo "       The upgrade path only fires when the new build is newer. Bump the" >&2
-    echo "       active-development version first, or pass an older baseline:" >&2
-    echo "         composer test:upgrade -- 5.6.0-beta2" >&2
-    exit 1
+    echo "NOT APPLICABLE: active-development version ($NEWVER) equals the baseline." >&2
+    echo "                The upgrade path only fires when the new build is newer," >&2
+    echo "                so there is nothing to test until the next version bump." >&2
+    echo "                To test against an older release explicitly:" >&2
+    echo "                  composer test:upgrade -- 5.6.0-beta2" >&2
+    exit 3
 fi
 
 BASEZIP="build/dist/pkg_livingword-${BASEVER}.zip"


### PR DESCRIPTION
Follow-up to #110. Running `composer test:release` on current `main` produced:

```
 RELEASE GATE FAILED:
   - upgrade
```

Nothing is broken. Immediately after a release, `active_development` **is** the last release, so there is nothing newer to upgrade to and the `update()` path cannot fire. `test-upgrade.sh` correctly refused to run — but exited 1, so the gate was red between every release and the next bump.

A gate that is red for a non-defect is a gate people learn to ignore, which costs more than the phase is worth.

## Change

`test-upgrade.sh` exits **3** for "not applicable"; `test-release.sh` maps 3 to SKIPPED rather than a failure. A genuinely missing baseline artifact still exits 1 and still fails the gate.

The skip is reported loudly and the summary line changes to admit it:

```
 SKIPPED (not applicable): upgrade
 RELEASE GATE PASSED — with the phase(s) above not applicable.
```

rather than the unqualified "install, upgrade and accessibility all verified". A silently skipped phase reads as a pass, and that is how an ungated release happens — the same failure shape as the error-page scan in #108 and the changelog that generated nothing in #88.

## Verified

Both states exercised on this branch: skipped when versions match, and the full three-phase run when they don't (as in #110, where the upgrade phase ran and passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)