### PR TITLE
revert(compat): withdraw the Joomla 7 declaration

### DIFF
--- a/livingword.xml
+++ b/livingword.xml
@@ -15,7 +15,6 @@
         <cms>
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
-            <targetplatform name="joomla" version="7[.0-9]" />
         </cms>
         <php minimum="8.3.0" />
     </compatibility>

--- a/mod_livingword/mod_livingword.xml
+++ b/mod_livingword/mod_livingword.xml
@@ -15,7 +15,6 @@
         <cms>
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
-            <targetplatform name="joomla" version="7[.0-9]" />
         </cms>
         <php minimum="8.3.0" />
     </compatibility>

--- a/plg_task_livingword/livingword.xml
+++ b/plg_task_livingword/livingword.xml
@@ -15,7 +15,6 @@
         <cms>
             <targetplatform name="joomla" version="5[.0-9]" />
             <targetplatform name="joomla" version="6[.0-9]" />
-            <targetplatform name="joomla" version="7[.0-9]" />
         </cms>
         <php minimum="8.3.0" />
     </compatibility>


### PR DESCRIPTION
Reverts #107. Premature on two counts.

## ARS cannot serve Joomla 7 sites

The update stream still filters on `((5)|(6))` and there is no Joomla 7 environment to add. The manifest would have advertised support the release infrastructure cannot deliver.

## `<targetplatform>` is a public claim

The Extension Manager shows it and JED tooling reads it. My argument in #107 — that it is not enforced at install, so declaring early is nearly free — established that the **cost** was low, not that the **claim** was true.

It wasn't. The evidence was a single smoke test against `7.0.0-alpha1-dev`: an unreleased, moving target, covering install and one rendered view. That is not a basis for telling users we support Joomla 7.

## The evidence still stands and is worth keeping

From that test, LivingWord 5.6.0 on Joomla 7 alpha:

- installs cleanly; all four extensions register
- creates all nine tables
- the task plugin's install script enables it, as on 5.x/6.x
- the seeded menu resolves and the site view renders over SEF routing, no PHP errors

A good sign for when the time comes. Not grounds for a support claim today.

## Re-entry criteria

Worth declaring when all three hold, not before:

1. Joomla 7.0 has an actual release — not alpha or beta
2. ARS has a Joomla 7 environment, and stream 6's platform filter includes it
3. The release gate has run against a 7.0 release, not a moving `-dev` snapshot

#97 stays open and now tracks that, rather than the manifest edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)