### PR TITLE
feat(api): Web Services API for catalog and user data

### DIFF
--- a/admin/src/Model/CwmnotesModel.php
+++ b/admin/src/Model/CwmnotesModel.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @package    Livingword.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Administrator\Model;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+use Joomla\Database\QueryInterface;
+
+/**
+ * Per-day reflection notes, always scoped to one user.
+ *
+ * The same scoping contract as CwmprogressModel: getListQuery() constrains
+ * user_id from `filter.user_id`, defaulting to 0 so a caller that forgets the
+ * scope reads nothing rather than everything.
+ *
+ * Notes are the most private data the component holds — a person's written
+ * reflections on scripture. Nothing here should ever be readable by another
+ * user, including a site administrator through this model.
+ *
+ * @since  5.7.0
+ */
+class CwmnotesModel extends ListModel
+{
+    /**
+     * @param   array  $config  Configuration settings.
+     *
+     * @throws  \Exception
+     * @since   5.7.0
+     */
+    public function __construct($config = [])
+    {
+        if (empty($config['filter_fields'])) {
+            $config['filter_fields'] = [
+                'id', 'a.id',
+                'plan_id', 'a.plan_id',
+                'day', 'a.day',
+                'modified', 'a.modified',
+            ];
+        }
+
+        parent::__construct($config);
+    }
+
+    /**
+     * @param   string  $ordering   Default ordering field.
+     * @param   string  $direction  Default ordering direction.
+     *
+     * @return  void
+     *
+     * @throws  \Exception
+     * @since   5.7.0
+     */
+    protected function populateState($ordering = 'a.modified', $direction = 'desc'): void
+    {
+        parent::populateState($ordering, $direction);
+    }
+
+    /**
+     * Build the query, scoped to the user in state.
+     *
+     * @return  QueryInterface
+     *
+     * @since   5.7.0
+     */
+    protected function getListQuery(): QueryInterface
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true);
+
+        $query->select(
+            $db->quoteName(['a.id', 'a.user_id', 'a.plan_id', 'a.day', 'a.note_text', 'a.created', 'a.modified'])
+        )->from($db->quoteName('#__livingword_notes', 'a'));
+
+        $userId = (int) $this->getState('filter.user_id', 0);
+        $query->where($db->quoteName('a.user_id') . ' = :userId')
+            ->bind(':userId', $userId, ParameterType::INTEGER);
+
+        $planId = (int) $this->getState('filter.plan_id', 0);
+
+        if ($planId > 0) {
+            $query->where($db->quoteName('a.plan_id') . ' = :planId')
+                ->bind(':planId', $planId, ParameterType::INTEGER);
+        }
+
+        $day = $this->getState('filter.day');
+
+        if (is_numeric($day)) {
+            $dayValue = (int) $day;
+            $query->where($db->quoteName('a.day') . ' = :day')
+                ->bind(':day', $dayValue, ParameterType::INTEGER);
+        }
+
+        $orderCol  = $this->state->get('list.ordering', 'a.modified');
+        $orderDirn = $this->state->get('list.direction', 'desc');
+        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+
+        return $query;
+    }
+}

--- a/admin/src/Model/CwmprogressModel.php
+++ b/admin/src/Model/CwmprogressModel.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @package    Livingword.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Administrator\Model;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\QueryInterface;
+
+/**
+ * Reading progress, always scoped to one user.
+ *
+ * Exists for the Web Services API: progress was previously reachable only
+ * through CwmprogressHelper from the site controllers, and both ApiController
+ * and JsonApiView require a model.
+ *
+ * **The user scope is applied here, not by callers.** getListQuery() always
+ * constrains user_id, and the id comes from `filter.user_id` in the model
+ * state — which the API controller sets from the authenticated session and
+ * never from request input. A caller that forgets to set it gets no rows
+ * rather than everyone's rows: the default is 0, which matches nobody.
+ *
+ * That default is the whole safety property. Progress is a record of what a
+ * person has read and when; leaking it across users would be a privacy breach,
+ * not a bug in a listing.
+ *
+ * @since  5.7.0
+ */
+class CwmprogressModel extends ListModel
+{
+    /**
+     * @param   array  $config  Configuration settings.
+     *
+     * @throws  \Exception
+     * @since   5.7.0
+     */
+    public function __construct($config = [])
+    {
+        if (empty($config['filter_fields'])) {
+            $config['filter_fields'] = [
+                'id', 'a.id',
+                'plan_id', 'a.plan_id',
+                'day', 'a.day',
+                'passage_index', 'a.passage_index',
+                'completed_at', 'a.completed_at',
+            ];
+        }
+
+        parent::__construct($config);
+    }
+
+    /**
+     * @param   string  $ordering   Default ordering field.
+     * @param   string  $direction  Default ordering direction.
+     *
+     * @return  void
+     *
+     * @throws  \Exception
+     * @since   5.7.0
+     */
+    protected function populateState($ordering = 'a.completed_at', $direction = 'desc'): void
+    {
+        parent::populateState($ordering, $direction);
+    }
+
+    /**
+     * Build the query, scoped to the user in state.
+     *
+     * @return  QueryInterface
+     *
+     * @since   5.7.0
+     */
+    protected function getListQuery(): QueryInterface
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true);
+
+        $query->select(
+            $db->quoteName(['a.id', 'a.user_id', 'a.plan_id', 'a.day', 'a.passage_index', 'a.completed_at'])
+        )->from($db->quoteName('#__livingword_progress', 'a'));
+
+        // Defaults to 0 — matches no user — so a caller that fails to set the
+        // scope reads nothing instead of reading everything.
+        $userId = (int) $this->getState('filter.user_id', 0);
+        $query->where($db->quoteName('a.user_id') . ' = :userId')
+            ->bind(':userId', $userId, \Joomla\Database\ParameterType::INTEGER);
+
+        $planId = (int) $this->getState('filter.plan_id', 0);
+
+        if ($planId > 0) {
+            $query->where($db->quoteName('a.plan_id') . ' = :planId')
+                ->bind(':planId', $planId, \Joomla\Database\ParameterType::INTEGER);
+        }
+
+        $day = $this->getState('filter.day');
+
+        if (is_numeric($day)) {
+            $dayValue = (int) $day;
+            $query->where($db->quoteName('a.day') . ' = :day')
+                ->bind(':day', $dayValue, \Joomla\Database\ParameterType::INTEGER);
+        }
+
+        $orderCol  = $this->state->get('list.ordering', 'a.completed_at');
+        $orderDirn = $this->state->get('list.direction', 'desc');
+        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+
+        return $query;
+    }
+}

--- a/admin/src/Model/CwmsettingsModel.php
+++ b/admin/src/Model/CwmsettingsModel.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @package    Livingword.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Administrator\Model;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+use Joomla\Database\QueryInterface;
+
+/**
+ * A user's own LivingWord settings.
+ *
+ * A singleton per user — one row in #__livingword_users — but modelled as a
+ * ListModel because that is what ApiController::displayList consumes. A client
+ * gets a collection of one, or of none before the user has any settings saved.
+ *
+ * **Two columns are deliberately never selected.** `unsubscribe_token` and
+ * `action_token` are credentials, not settings: the first cancels a
+ * subscription and the second marks readings complete, both from an emailed
+ * link with no further authentication. Publishing either over the API would
+ * hand any client that reads a user's settings the ability to act as them by
+ * email link. The column list here is the control, so they cannot be exposed
+ * by a view that renders whatever it is given.
+ *
+ * `accountability_partner_id` is also withheld: it names another user, and it
+ * is that user's relationship to disclose, not this one's.
+ *
+ * @since  5.7.0
+ */
+class CwmsettingsModel extends ListModel
+{
+    /**
+     * Columns safe to return over the API.
+     *
+     * Listed positively rather than excluding the sensitive ones, so a column
+     * added to the table later is withheld until someone decides otherwise.
+     *
+     * @var    string[]
+     * @since  5.7.0
+     */
+    public const PUBLIC_COLUMNS = [
+        'a.id',
+        'a.user_id',
+        'a.plan_id',
+        'a.bible_version',
+        'a.audio_version',
+        'a.email',
+        'a.plan_view',
+        'a.start_date',
+        'a.date_offset',
+        'a.streak_current',
+        'a.streak_best',
+        'a.streak_last_date',
+        'a.email_hour',
+        'a.timezone',
+        'a.share_progress',
+        'a.created',
+        'a.modified',
+    ];
+
+    /**
+     * @param   array  $config  Configuration settings.
+     *
+     * @throws  \Exception
+     * @since   5.7.0
+     */
+    public function __construct($config = [])
+    {
+        if (empty($config['filter_fields'])) {
+            $config['filter_fields'] = ['id', 'a.id', 'plan_id', 'a.plan_id'];
+        }
+
+        parent::__construct($config);
+    }
+
+    /**
+     * Build the query, scoped to the user in state.
+     *
+     * @return  QueryInterface
+     *
+     * @since   5.7.0
+     */
+    protected function getListQuery(): QueryInterface
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true);
+
+        $query->select($db->quoteName(self::PUBLIC_COLUMNS))
+            ->from($db->quoteName('#__livingword_users', 'a'));
+
+        // 0 matches no user: a caller that fails to scope reads nothing.
+        $userId = (int) $this->getState('filter.user_id', 0);
+        $query->where($db->quoteName('a.user_id') . ' = :userId')
+            ->bind(':userId', $userId, ParameterType::INTEGER);
+
+        return $query;
+    }
+}

--- a/api/src/Controller/AbstractReadOnlyController.php
+++ b/api/src/Controller/AbstractReadOnlyController.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\Router\Exception\RouteNotFoundException;
+
+/**
+ * Base controller for resources the API exposes read-only.
+ *
+ * The catalog — plans, plan days, tools, links, groups — is content an
+ * administrator curates in the backend. Letting it be rewritten over HTTP
+ * would put site content behind an API token rather than behind the ACL and
+ * the edit forms, which is a different security model than the one the
+ * component was built with.
+ *
+ * The webservices plugin already declines to register write routes for these,
+ * so this class is defence in depth: a resource cannot become writable by
+ * accident if a route is added elsewhere, or if the controller is dispatched
+ * directly. RouteNotFoundException is what ApiApplication turns into a 404,
+ * which is the honest answer — for these resources the write route genuinely
+ * does not exist.
+ *
+ * @since  5.7.0
+ */
+abstract class AbstractReadOnlyController extends ApiController
+{
+    /**
+     * Creating is not supported for this resource.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Always.
+     *
+     * @since   5.7.0
+     */
+    public function add()
+    {
+        throw new RouteNotFoundException($this->readOnlyMessage('created'));
+    }
+
+    /**
+     * Editing is not supported for this resource.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Always.
+     *
+     * @since   5.7.0
+     */
+    public function edit()
+    {
+        throw new RouteNotFoundException($this->readOnlyMessage('edited'));
+    }
+
+    /**
+     * Deleting is not supported for this resource.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Always.
+     *
+     * @since   5.7.0
+     */
+    public function delete($id = null)
+    {
+        throw new RouteNotFoundException($this->readOnlyMessage('deleted'));
+    }
+
+    /**
+     * Build the message explaining why a write was refused.
+     *
+     * @param   string  $verb  Past-tense verb for the refused operation.
+     *
+     * @return  string
+     *
+     * @since   5.7.0
+     */
+    private function readOnlyMessage(string $verb): string
+    {
+        return \sprintf(
+            'LivingWord %s are read-only over the API and cannot be %s. Manage them in the administrator.',
+            $this->contentType,
+            $verb
+        );
+    }
+}

--- a/api/src/Controller/AbstractUserScopedController.php
+++ b/api/src/Controller/AbstractUserScopedController.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Router\Exception\RouteNotFoundException;
+
+/**
+ * Base controller for resources that belong to the authenticated user.
+ *
+ * Progress, notes and settings are personal records — what someone has read,
+ * what they wrote about it, when they want their email. The entire security
+ * property of these endpoints is that a request can only ever reach the
+ * requester's own rows.
+ *
+ * That is enforced in one place: {@see self::userId()} reads the identity from
+ * the application and nothing else. No route carries a user id, no method
+ * accepts one, and any `user_id` a client sends in a body or query string is
+ * ignored — it is never read, so it cannot be honoured by accident.
+ *
+ * The models apply the scope themselves and default to user 0, which matches
+ * nobody. So the failure mode of a controller that forgets to set the scope is
+ * an empty result, not somebody else's reading history.
+ *
+ * @since  5.7.0
+ */
+abstract class AbstractUserScopedController extends ApiController
+{
+    /**
+     * Administrator model backing this resource, e.g. 'Cwmprogress'.
+     *
+     * Declared here because ApiController has no such property — it resolves
+     * models from the view name, and these resources do not share a name with
+     * their model.
+     *
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $modelName = '';
+
+    /**
+     * The authenticated user's id.
+     *
+     * @return  int
+     *
+     * @throws  RouteNotFoundException  When there is no authenticated user.
+     *
+     * @since   5.7.0
+     */
+    protected function userId(): int
+    {
+        $identity = $this->app->getIdentity();
+        $id       = $identity ? (int) $identity->id : 0;
+
+        if ($id < 1) {
+            // The routes are registered with public => false, so the API
+            // application should have rejected this already. Refusing here too
+            // means a misconfigured route cannot turn a personal resource into
+            // an anonymous one.
+            throw new RouteNotFoundException(
+                'LivingWord user data requires an authenticated user.'
+            );
+        }
+
+        return $id;
+    }
+
+    /**
+     * Apply the user scope to the model state before a read.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    protected function scopeToUser(): void
+    {
+        $this->modelState->set('filter.user_id', $this->userId());
+    }
+
+    /**
+     * List the current user's records.
+     *
+     * @return  static
+     *
+     * @since   5.7.0
+     */
+    public function displayList()
+    {
+        $this->scopeToUser();
+
+        return parent::displayList();
+    }
+
+    /**
+     * Show one of the current user's records.
+     *
+     * @param   integer  $id  The record id.
+     *
+     * @return  static
+     *
+     * @since   5.7.0
+     */
+    public function displayItem($id = null)
+    {
+        $this->scopeToUser();
+
+        return parent::displayItem($id);
+    }
+
+    /**
+     * Writes are implemented per resource, not inherited.
+     *
+     * ApiController::add() and ::edit() drive an AdminModel's save(), which
+     * expects a form, a table and a bind/validate cycle. These resources are
+     * backed by ListModels over rows a user accumulates by reading, and their
+     * write semantics are not "save a record" — marking a day complete is
+     * idempotent, and saving an empty note deletes it. So each controller
+     * implements its own, and anything that has not is refused rather than
+     * fatally calling save() on a model that does not have one.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Unless a subclass overrides this.
+     *
+     * @since   5.7.0
+     */
+    public function add()
+    {
+        throw new RouteNotFoundException(
+            \sprintf('Creating LivingWord %s over the API is not supported.', $this->contentType)
+        );
+    }
+
+    /**
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Unless a subclass overrides this.
+     *
+     * @since   5.7.0
+     */
+    public function edit()
+    {
+        throw new RouteNotFoundException(
+            \sprintf('Editing LivingWord %s over the API is not supported.', $this->contentType)
+        );
+    }
+
+    /**
+     * @param   integer  $id  The record id.
+     *
+     * @return  void
+     *
+     * @throws  RouteNotFoundException  Unless a subclass overrides this.
+     *
+     * @since   5.7.0
+     */
+    public function delete($id = null)
+    {
+        throw new RouteNotFoundException(
+            \sprintf('Deleting LivingWord %s over the API is not supported.', $this->contentType)
+        );
+    }
+
+    /**
+     * Read a positive integer from the request body or query string.
+     *
+     * @param   string  $key  Field name.
+     *
+     * @return  int  Zero when absent or not positive.
+     *
+     * @since   5.7.0
+     */
+    protected function requestInt(string $key): int
+    {
+        $body = (array) $this->input->json->get('data', [], 'array');
+
+        if (isset($body['attributes'][$key])) {
+            return (int) $body['attributes'][$key];
+        }
+
+        if (isset($body[$key])) {
+            return (int) $body[$key];
+        }
+
+        return $this->input->getInt($key, 0);
+    }
+
+    /**
+     * Resolve the Administrator model backing this resource.
+     *
+     * @param   string  $name    Model name.
+     * @param   string  $prefix  Model prefix.
+     * @param   array   $config  Model configuration.
+     *
+     * @return  BaseDatabaseModel
+     *
+     * @since   5.7.0
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if ($name === '') {
+            $name = $this->modelName;
+        }
+
+        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+    }
+}

--- a/api/src/Controller/GroupsController.php
+++ b/api/src/Controller/GroupsController.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * Reading groups, read-only.
+ *
+ * @since  5.7.0
+ */
+class GroupsController extends AbstractReadOnlyController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'groups';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'groups';
+
+    /**
+     * Resolve the Administrator models that back this resource.
+     *
+     * The API reuses the backend models rather than duplicating their queries,
+     * so a filter or a join fixed there is fixed here too.
+     *
+     * @param   string  $name    Model name.
+     * @param   string  $prefix  Model prefix.
+     * @param   array   $config  Model configuration.
+     *
+     * @return  BaseDatabaseModel
+     *
+     * @since   5.7.0
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if ($name === '') {
+            $name = $this->input->get('id') ? 'Cwmgroup' : 'Cwmgroups';
+        }
+
+        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+    }
+}

--- a/api/src/Controller/LinksController.php
+++ b/api/src/Controller/LinksController.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * Curated Bible resource links, read-only.
+ *
+ * @since  5.7.0
+ */
+class LinksController extends AbstractReadOnlyController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'links';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'links';
+
+    /**
+     * Resolve the Administrator models that back this resource.
+     *
+     * The API reuses the backend models rather than duplicating their queries,
+     * so a filter or a join fixed there is fixed here too.
+     *
+     * @param   string  $name    Model name.
+     * @param   string  $prefix  Model prefix.
+     * @param   array   $config  Model configuration.
+     *
+     * @return  BaseDatabaseModel
+     *
+     * @since   5.7.0
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if ($name === '') {
+            $name = $this->input->get('id') ? 'Cwmlink' : 'Cwmlinks';
+        }
+
+        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+    }
+}

--- a/api/src/Controller/NotesController.php
+++ b/api/src/Controller/NotesController.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Livingword\Site\Helper\CwmnotesHelper;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * The authenticated user's per-day reflection notes.
+ *
+ * Scoping is inherited from AbstractUserScopedController: every read is
+ * constrained to the authenticated user, and no user id is ever read from the
+ * request.
+ *
+ * @since  5.7.0
+ */
+class NotesController extends AbstractUserScopedController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'notes';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'notes';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $modelName = 'Cwmnotes';
+
+    /**
+     * Save the authenticated user's note for a day.
+     *
+     * Upsert rather than create: a user has at most one note per plan-day, so
+     * POSTing twice edits rather than duplicating. Saving an empty note deletes
+     * it, which is what CwmnotesHelper::saveNote() already does for the site.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    public function add()
+    {
+        $userId = $this->userId();
+        $planId = $this->requestInt('plan_id');
+        $day    = $this->requestInt('day');
+
+        if ($planId < 1 || $day < 1) {
+            throw new \InvalidArgumentException('plan_id and day are required and must be positive.', 400);
+        }
+
+        $body = (array) $this->input->json->get('data', [], 'array');
+        $text = (string) ($body['attributes']['note_text'] ?? $body['note_text'] ?? $this->input->getString('note_text', ''));
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $saved = CwmnotesHelper::saveNote($db, $userId, $planId, $day, $text);
+
+        $this->app->setHeader('status', 200);
+        $this->app->sendHeaders();
+
+        echo json_encode([
+            'data' => [
+                'type'       => 'notes',
+                'attributes' => [
+                    'plan_id' => $planId,
+                    'day'     => $day,
+                    'saved'   => $saved,
+                    'deleted' => trim($text) === '',
+                ],
+            ],
+        ]);
+
+        $this->app->close();
+    }
+}

--- a/api/src/Controller/PlandaysController.php
+++ b/api/src/Controller/PlandaysController.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * Daily readings within a reading plan, read-only.
+ *
+ * @since  5.7.0
+ */
+class PlandaysController extends AbstractReadOnlyController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'plandays';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'plandays';
+
+    /**
+     * Resolve the Administrator models that back this resource.
+     *
+     * The API reuses the backend models rather than duplicating their queries,
+     * so a filter or a join fixed there is fixed here too.
+     *
+     * @param   string  $name    Model name.
+     * @param   string  $prefix  Model prefix.
+     * @param   array   $config  Model configuration.
+     *
+     * @return  BaseDatabaseModel
+     *
+     * @since   5.7.0
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if ($name === '') {
+            $name = $this->input->get('id') ? 'Cwmplandetail' : 'Cwmplandetails';
+        }
+
+        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+    }
+}

--- a/api/src/Controller/PlansController.php
+++ b/api/src/Controller/PlansController.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * Reading plans, read-only.
+ *
+ * @since  5.7.0
+ */
+class PlansController extends AbstractReadOnlyController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'plans';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'plans';
+
+    /**
+     * Resolve the Administrator models that back this resource.
+     *
+     * The API reuses the backend models rather than duplicating their queries,
+     * so a filter or a join fixed there is fixed here too.
+     *
+     * @param   string  $name    Model name.
+     * @param   string  $prefix  Model prefix.
+     * @param   array   $config  Model configuration.
+     *
+     * @return  BaseDatabaseModel
+     *
+     * @since   5.7.0
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if ($name === '') {
+            $name = $this->input->get('id') ? 'Cwmplan' : 'Cwmplans';
+        }
+
+        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+    }
+}

--- a/api/src/Controller/ProgressController.php
+++ b/api/src/Controller/ProgressController.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * The authenticated user's reading progress.
+ *
+ * Scoping is inherited from AbstractUserScopedController: every read is
+ * constrained to the authenticated user, and no user id is ever read from the
+ * request.
+ *
+ * @since  5.7.0
+ */
+class ProgressController extends AbstractUserScopedController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'progress';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'progress';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $modelName = 'Cwmprogress';
+
+    /**
+     * Mark a reading complete for the authenticated user.
+     *
+     * Idempotent by design: marking a day already complete is a no-op rather
+     * than an error, because a mobile client that retries after a dropped
+     * connection must not be punished for it.
+     *
+     * plan_id and day come from the request; the user never does.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    public function add()
+    {
+        $userId = $this->userId();
+        $planId = $this->requestInt('plan_id');
+        $day    = $this->requestInt('day');
+
+        if ($planId < 1 || $day < 1) {
+            throw new \InvalidArgumentException('plan_id and day are required and must be positive.', 400);
+        }
+
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        // passage_index is optional: a reading with several passages can be
+        // ticked off one at a time, or the whole day at once.
+        $passageIndex = $this->requestInt('passage_index');
+
+        if ($passageIndex > 0) {
+            CwmprogressHelper::markPassageComplete($db, $userId, $planId, $day, $passageIndex);
+        } else {
+            CwmprogressHelper::markComplete($db, $userId, $planId, $day);
+        }
+
+        $this->app->setHeader('status', 201);
+        $this->app->sendHeaders();
+
+        echo json_encode([
+            'data' => [
+                'type'       => 'progress',
+                'attributes' => [
+                    'plan_id'       => $planId,
+                    'day'           => $day,
+                    'passage_index' => $passageIndex,
+                    'completed'     => true,
+                ],
+            ],
+        ]);
+
+        $this->app->close();
+    }
+}

--- a/api/src/Controller/SettingsController.php
+++ b/api/src/Controller/SettingsController.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+
+/**
+ * The authenticated user's LivingWord settings.
+ *
+ * Scoping is inherited from AbstractUserScopedController: every read is
+ * constrained to the authenticated user, and no user id is ever read from the
+ * request.
+ *
+ * @since  5.7.0
+ */
+class SettingsController extends AbstractUserScopedController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'settings';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'settings';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $modelName = 'Cwmsettings';
+
+    /**
+     * Fields a client may change.
+     *
+     * An allowlist, not a denylist. Everything absent is unwritable:
+     *
+     *   - unsubscribe_token, action_token are credentials. A client that could
+     *     set them could choose a token and then act as the user by email link.
+     *   - streak_current, streak_best, streak_last_date are earned by reading.
+     *     Letting a client post them makes the streak a claim rather than a
+     *     record.
+     *   - user_id decides whose row this is. It comes from the session.
+     *   - accountability_partner_id names another user, and pairing is that
+     *     user's decision too, not a field one side can set unilaterally.
+     *
+     * @var    string[]
+     * @since  5.7.0
+     */
+    private const WRITABLE = [
+        'plan_id',
+        'bible_version',
+        'audio_version',
+        'email',
+        'plan_view',
+        'start_date',
+        'date_offset',
+        'email_hour',
+        'timezone',
+        'share_progress',
+    ];
+
+    /**
+     * Patch the authenticated user's settings.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    public function edit()
+    {
+        $userId = $this->userId();
+        $body   = (array) $this->input->json->get('data', [], 'array');
+        $attrs  = (array) ($body['attributes'] ?? $body);
+
+        $changes = array_intersect_key($attrs, array_flip(self::WRITABLE));
+
+        if ($changes === []) {
+            throw new \InvalidArgumentException(
+                'No writable settings supplied. Writable: ' . implode(', ', self::WRITABLE) . '.',
+                400
+            );
+        }
+
+        $db     = Factory::getContainer()->get(DatabaseInterface::class);
+        $query  = $db->getQuery(true)->update($db->quoteName('#__livingword_users'));
+
+        foreach ($changes as $column => $value) {
+            $query->set($db->quoteName($column) . ' = ' . $db->quote((string) $value));
+        }
+
+        $query->set($db->quoteName('modified') . ' = ' . $db->quote(Factory::getDate()->toSql()))
+            ->where($db->quoteName('user_id') . ' = :userId')
+            ->bind(':userId', $userId, ParameterType::INTEGER);
+
+        $db->setQuery($query)->execute();
+
+        $this->app->setHeader('status', 200);
+        $this->app->sendHeaders();
+
+        echo json_encode([
+            'data' => [
+                'type'       => 'settings',
+                'attributes' => ['updated' => array_keys($changes)],
+            ],
+        ]);
+
+        $this->app->close();
+    }
+}

--- a/api/src/Controller/ToolsController.php
+++ b/api/src/Controller/ToolsController.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * Study tools catalog, read-only.
+ *
+ * @since  5.7.0
+ */
+class ToolsController extends AbstractReadOnlyController
+{
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $contentType = 'tools';
+
+    /**
+     * @var    string
+     * @since  5.7.0
+     */
+    protected $default_view = 'tools';
+
+    /**
+     * Resolve the Administrator models that back this resource.
+     *
+     * The API reuses the backend models rather than duplicating their queries,
+     * so a filter or a join fixed there is fixed here too.
+     *
+     * @param   string  $name    Model name.
+     * @param   string  $prefix  Model prefix.
+     * @param   array   $config  Model configuration.
+     *
+     * @return  BaseDatabaseModel
+     *
+     * @since   5.7.0
+     */
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if ($name === '') {
+            $name = $this->input->get('id') ? 'Cwmtool' : 'Cwmtools';
+        }
+
+        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+    }
+}

--- a/api/src/View/Groups/JsonapiView.php
+++ b/api/src/View/Groups/JsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Groups;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Reading groups. The invite_token is deliberately never rendered — it is the credential that lets someone join.
+ *
+ * Fields are listed explicitly rather than serialising the row: a column added
+ * later — a token, an internal flag — is then not published by default.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'name', 'plan_id', 'start_date', 'join_mode', 'created_by'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'name', 'plan_id', 'join_mode'];
+}

--- a/api/src/View/Links/JsonapiView.php
+++ b/api/src/View/Links/JsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Links;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Curated Bible resource links.
+ *
+ * Fields are listed explicitly rather than serialising the row: a column added
+ * later — a token, an internal flag — is then not published by default.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'name', 'url', 'catid', 'target', 'published', 'ordering'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'name', 'url', 'catid', 'published'];
+}

--- a/api/src/View/Notes/JsonapiView.php
+++ b/api/src/View/Notes/JsonapiView.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Notes;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Reflection notes for the authenticated user.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'user_id', 'plan_id', 'day', 'note_text', 'created', 'modified'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'plan_id', 'day', 'note_text', 'modified'];
+}

--- a/api/src/View/Plandays/JsonapiView.php
+++ b/api/src/View/Plandays/JsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Plandays;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Daily readings within a plan.
+ *
+ * Fields are listed explicitly rather than serialising the row: a column added
+ * later — a token, an internal flag — is then not published by default.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'plan_id', 'ordering', 'reading', 'audio', 'descrip'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'plan_id', 'ordering', 'reading'];
+}

--- a/api/src/View/Plans/JsonapiView.php
+++ b/api/src/View/Plans/JsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Plans;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Reading plans.
+ *
+ * Fields are listed explicitly rather than serialising the row: a column added
+ * later — a token, an internal flag — is then not published by default.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'title', 'alias', 'description', 'message', 'duration_type', 'total_days', 'testament', 'audio_enabled', 'published'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'title', 'alias', 'duration_type', 'total_days', 'published'];
+}

--- a/api/src/View/Progress/JsonapiView.php
+++ b/api/src/View/Progress/JsonapiView.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Progress;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Reading progress for the authenticated user.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'user_id', 'plan_id', 'day', 'passage_index', 'completed_at'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'plan_id', 'day', 'passage_index', 'completed_at'];
+}

--- a/api/src/View/Settings/JsonapiView.php
+++ b/api/src/View/Settings/JsonapiView.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Settings;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Settings for the authenticated user. The token columns are never selected by the model, so they cannot be rendered here.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'user_id', 'plan_id', 'bible_version', 'audio_version', 'email', 'plan_view', 'start_date', 'date_offset', 'streak_current', 'streak_best', 'streak_last_date', 'email_hour', 'timezone', 'share_progress'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'plan_id', 'bible_version', 'plan_view', 'streak_current', 'streak_best', 'email_hour', 'timezone'];
+}

--- a/api/src/View/Tools/JsonapiView.php
+++ b/api/src/View/Tools/JsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package    Livingword.Api
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Api\View\Tools;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * Study tools.
+ *
+ * Fields are listed explicitly rather than serialising the row: a column added
+ * later — a token, an internal flag — is then not published by default.
+ *
+ * @since  5.7.0
+ */
+class JsonapiView extends BaseApiView
+{
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderItem = ['id', 'name', 'description', 'url', 'icon', 'color', 'catid', 'published'];
+
+    /**
+     * @var    array
+     * @since  5.7.0
+     */
+    protected $fieldsToRenderList = ['id', 'name', 'url', 'icon', 'catid', 'published'];
+}

--- a/build/pkg_livingword.xml
+++ b/build/pkg_livingword.xml
@@ -36,6 +36,7 @@
         <file type="component" id="com_livingword">com_livingword.zip</file>
         <file type="module" client="site" id="mod_livingword">mod_livingword.zip</file>
         <file type="plugin" group="task" id="livingword">plg_task_livingword.zip</file>
+        <file type="plugin" group="webservices" id="livingword">plg_webservices_livingword.zip</file>
         <file type="plugin" group="task" id="cwmscripture">plg_task_cwmscripture.zip</file>
         <file type="plugin" group="content" id="scripturelinks">plg_content_scripturelinks.zip</file>
     </files>

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
   "autoload": {
     "psr-4": {
       "CWM\\Component\\Livingword\\Administrator\\": "admin/src/",
+      "CWM\\Component\\Livingword\\Api\\": "api/src/",
       "CWM\\Component\\Livingword\\Site\\": "site/src/"
     }
   },
@@ -56,9 +57,20 @@
   "extra": {
     "cwm-build-tools": {
       "joomlaLinks": [
-        { "type": "component", "name": "com_livingword" },
-        { "type": "module",    "name": "mod_livingword", "client": "site" },
-        { "type": "plugin",    "group": "task", "element": "livingword" }
+        {
+          "type": "component",
+          "name": "com_livingword"
+        },
+        {
+          "type": "module",
+          "name": "mod_livingword",
+          "client": "site"
+        },
+        {
+          "type": "plugin",
+          "group": "task",
+          "element": "livingword"
+        }
       ]
     }
   },
@@ -87,41 +99,45 @@
     "joomla/string": "^4.0"
   },
   "scripts": {
-    "test":               "phpunit",
-    "test:unit":          "phpunit --testsuite 'LivingWord Unit Tests'",
-    "test:integration":   "phpunit --testsuite 'LivingWord Integration Tests'",
-    "lint:syntax":        "find admin site mod_livingword plg_task_livingword -name '*.php' -print0 | xargs -0 -n1 -P4 php -l",
-    "lint":               "php-cs-fixer fix --dry-run --diff",
-    "lint:fix":           "php-cs-fixer fix",
-    "lint:js":            "npm run lint:js",
-    "build:js":           "npm run build:js",
-    "build:css":          "npm run build:css",
-    "check":              ["@lint:syntax", "@lint", "@test"],
-    "install-zip":        "cwm-install-zip",
+    "test": "phpunit",
+    "test:unit": "phpunit --testsuite 'LivingWord Unit Tests'",
+    "test:integration": "phpunit --testsuite 'LivingWord Integration Tests'",
+    "lint:syntax": "find admin site mod_livingword plg_task_livingword -name '*.php' -print0 | xargs -0 -n1 -P4 php -l",
+    "lint": "php-cs-fixer fix --dry-run --diff",
+    "lint:fix": "php-cs-fixer fix",
+    "lint:js": "npm run lint:js",
+    "build:js": "npm run build:js",
+    "build:css": "npm run build:css",
+    "check": [
+      "@lint:syntax",
+      "@lint",
+      "@test"
+    ],
+    "install-zip": "cwm-install-zip",
     "test:reset-testsite": "@php build/reset-testsite.php",
-    "test:install":       "bash build/test-install.sh",
-    "test:migrations":    "@php build/verify-migrations.php",
-    "test:a11y":          "npm run test:a11y",
-    "test:e2e":           "npm run test:e2e",
-    "test:upgrade":       "bash build/test-upgrade.sh",
-    "test:release":       "bash build/test-release.sh",
-    "setup":              "cwm-setup",
-    "joomla-install":     "cwm-joomla-install",
-    "joomla-latest":      "cwm-joomla-latest",
-    "symlink":            "cwm-link",
-    "symlink:check":      "cwm-link-check",
-    "verify":             "cwm-verify",
-    "clean":              "cwm-clean",
-    "build":              "cwm-package",
-    "release":            "cwm-release",
-    "bump-version":       "cwm-bump",
-    "package":            "cwm-package",
-    "ars-publish":        "cwm-ars-publish",
-    "ars-list":           "cwm-ars-list",
-    "ars-create-stream":  "cwm-ars-create-stream",
-    "changelog":          "cwm-changelog",
-    "sync-configs":       "cwm-sync-configs",
-    "sync-languages":     "cwm-sync-languages",
+    "test:install": "bash build/test-install.sh",
+    "test:migrations": "@php build/verify-migrations.php",
+    "test:a11y": "npm run test:a11y",
+    "test:e2e": "npm run test:e2e",
+    "test:upgrade": "bash build/test-upgrade.sh",
+    "test:release": "bash build/test-release.sh",
+    "setup": "cwm-setup",
+    "joomla-install": "cwm-joomla-install",
+    "joomla-latest": "cwm-joomla-latest",
+    "symlink": "cwm-link",
+    "symlink:check": "cwm-link-check",
+    "verify": "cwm-verify",
+    "clean": "cwm-clean",
+    "build": "cwm-package",
+    "release": "cwm-release",
+    "bump-version": "cwm-bump",
+    "package": "cwm-package",
+    "ars-publish": "cwm-ars-publish",
+    "ars-list": "cwm-ars-list",
+    "ars-create-stream": "cwm-ars-create-stream",
+    "changelog": "cwm-changelog",
+    "sync-configs": "cwm-sync-configs",
+    "sync-languages": "cwm-sync-languages",
     "post-install-cmd": [
       "@php -r \"if (!file_exists('build.properties')) { copy('build.dist.properties', 'build.properties'); echo 'Created build.properties from template. Run composer setup to configure.\\n'; }\""
     ]

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -6,54 +6,102 @@
     },
     "profile": "package-wrapper",
     "manifests": {
-        "_comment": "All four manifests bump in lockstep on a LivingWord release. The bundled CWM Scripture extensions (lib_cwmscripture, plg_task_cwmscripture, plg_content_scripturelinks) live in the CWMScriptureLinks repo and are versioned there — they are pulled in as prebuilt zips by the preBuild hook (build/fetch_dependencies.php) and are NOT listed here. The scripture LIBRARY (joomla-bible-study/lib-cwmscripture) is pulled in as a Composer path repository from ../lib_cwmscripture; cwm-build-tools v1.1+ walks that dep's joomlaLinks and symlinks the library into the dev Joomla automatically (no dev.links[] entry required).",
+        "_comment": "All four manifests bump in lockstep on a LivingWord release. The bundled CWM Scripture extensions (lib_cwmscripture, plg_task_cwmscripture, plg_content_scripturelinks) live in the CWMScriptureLinks repo and are versioned there \u2014 they are pulled in as prebuilt zips by the preBuild hook (build/fetch_dependencies.php) and are NOT listed here. The scripture LIBRARY (joomla-bible-study/lib-cwmscripture) is pulled in as a Composer path repository from ../lib_cwmscripture; cwm-build-tools v1.1+ walks that dep's joomlaLinks and symlinks the library into the dev Joomla automatically (no dev.links[] entry required).",
         "package": "build/pkg_livingword.xml",
         "extensions": [
-            { "type": "component", "path": "livingword.xml" },
-            { "type": "module",    "path": "mod_livingword/mod_livingword.xml" },
-            { "type": "plugin",    "path": "plg_task_livingword/livingword.xml" }
+            {
+                "type": "component",
+                "path": "livingword.xml"
+            },
+            {
+                "type": "module",
+                "path": "mod_livingword/mod_livingword.xml"
+            },
+            {
+                "type": "plugin",
+                "path": "plg_task_livingword/livingword.xml"
+            },
+            {
+                "type": "plugin",
+                "path": "plg_webservices_livingword/livingword.xml"
+            }
         ]
     },
     "build": {
-        "_comment": "Builds com_livingword.zip — the component itself (admin/, site/, media/, livingword.xml, script.php). cwm-package runs this as the 'self' include, then bundles its output with the other 5 sub-zips into pkg_livingword-{version}.zip. The build.outputGlob points at the PACKAGE output (what cwm-release publishes), not the component output.",
-        "command":    "cwm-package",
+        "_comment": "Builds com_livingword.zip \u2014 the component itself (admin/, site/, media/, livingword.xml, script.php). cwm-package runs this as the 'self' include, then bundles its output with the other 5 sub-zips into pkg_livingword-{version}.zip. The build.outputGlob points at the PACKAGE output (what cwm-release publishes), not the component output.",
+        "command": "cwm-package",
         "outputGlob": "build/dist/pkg_livingword-*.zip",
-        "outputDir":  "build/dist",
+        "outputDir": "build/dist",
         "outputName": "com_livingword-{version}.zip",
-        "manifest":   "livingword.xml",
+        "manifest": "livingword.xml",
         "scriptFile": "script.php",
-        "sources":    [{ "from": ".", "to": "" }],
+        "sources": [
+            {
+                "from": ".",
+                "to": ""
+            }
+        ],
         "excludeMatchMode": "strict",
         "excludes": [
-            ".git", ".github", ".vscode", ".idea", ".DS_Store",
-            "node_modules", "build", "tests",
-            "build.properties", "build.dist.properties",
-            "composer.json", "composer.lock",
-            "package.json", "package-lock.json",
+            ".git",
+            ".github",
+            ".vscode",
+            ".idea",
+            ".DS_Store",
+            "node_modules",
+            "build",
+            "tests",
+            "build.properties",
+            "build.dist.properties",
+            "composer.json",
+            "composer.lock",
+            "package.json",
+            "package-lock.json",
             "eslint.config.mjs",
-            "phpunit.xml", "phpunit.xml.dist",
-            ".php-cs-fixer.dist.php", ".php-cs-fixer.cache",
-            "CLAUDE.md", "SECURITY.md", "README.md",
+            "phpunit.xml",
+            "phpunit.xml.dist",
+            ".php-cs-fixer.dist.php",
+            ".php-cs-fixer.cache",
+            "CLAUDE.md",
+            "SECURITY.md",
+            "README.md",
             "libraries",
-            "mod_livingword", "plg_task_livingword",
+            "mod_livingword",
+            "plg_task_livingword",
+            "plg_webservices_livingword",
             "cwm-build.config.json"
         ],
-        "excludeExtensions": ["map"],
+        "excludeExtensions": [
+            "map"
+        ],
         "vendorPrune": true,
-        "includeRoots": ["admin/", "site/", "media/"],
-        "includeRootExtensions": ["php", "xml", "txt", "md"],
+        "includeRoots": [
+            "admin/",
+            "site/",
+            "api/",
+            "media/"
+        ],
+        "includeRootExtensions": [
+            "php",
+            "xml",
+            "txt",
+            "md"
+        ],
         "preBuild": {
             "_comment": "Runs once before cwm-package assembles the bundle: (1) wipes build/dist and build/vendor so stale zips from prior builds can't be picked up by outputGlob (regression seen during v5.0.1 release where the stale 5.0.0 zip got published alongside 5.0.1), (2) installs npm deps if missing, (3) bundles JS via rollup and minifies CSS via csso into media/com_livingword/{js,css}/, (4) fetches the latest pkg_cwmscripture release from GitHub and extracts its 3 inner zips into build/vendor/ for the prebuilt includes below.",
             "mode": "run",
             "command": "rm -rf build/dist build/vendor && npm install --no-audit --no-fund && npm run build && php build/fetch_dependencies.php"
         },
-        "versionPrompt": { "enabled": true, "timeout": 10 }
+        "versionPrompt": {
+            "enabled": true,
+            "timeout": 10
+        }
     },
     "package": {
-        "_comment": "Assembles pkg_livingword-{version}.zip with 6 inner zips: com_livingword (self), mod_livingword + plg_task_livingword (inline — built from this repo), and 3 scripture zips (prebuilt — fetched from GitHub by the preBuild hook).",
-        "manifest":    "build/pkg_livingword.xml",
-        "outputDir":   "build/dist",
-        "outputName":  "pkg_livingword-{version}.zip",
+        "_comment": "Assembles pkg_livingword-{version}.zip with 6 inner zips: com_livingword (self), mod_livingword + plg_task_livingword (inline \u2014 built from this repo), and 3 scripture zips (prebuilt \u2014 fetched from GitHub by the preBuild hook).",
+        "manifest": "build/pkg_livingword.xml",
+        "outputDir": "build/dist",
+        "outputName": "pkg_livingword-{version}.zip",
         "innerLayout": "packages-prefix",
         "includes": [
             {
@@ -64,40 +112,82 @@
                 "type": "inline",
                 "outputName": "mod_livingword.zip",
                 "config": {
-                    "outputDir":  "build/dist",
+                    "outputDir": "build/dist",
                     "outputName": "mod_livingword-{version}.zip",
-                    "manifest":   "mod_livingword/mod_livingword.xml",
-                    "sources":    [{ "from": "mod_livingword", "to": "" }],
+                    "manifest": "mod_livingword/mod_livingword.xml",
+                    "sources": [
+                        {
+                            "from": "mod_livingword",
+                            "to": ""
+                        }
+                    ],
                     "excludeMatchMode": "strict",
-                    "excludes":   [".git", ".DS_Store", ".idea", "node_modules"]
+                    "excludes": [
+                        ".git",
+                        ".DS_Store",
+                        ".idea",
+                        "node_modules"
+                    ]
                 }
             },
             {
                 "type": "inline",
                 "outputName": "plg_task_livingword.zip",
                 "config": {
-                    "outputDir":  "build/dist",
+                    "outputDir": "build/dist",
                     "outputName": "plg_task_livingword-{version}.zip",
-                    "manifest":   "plg_task_livingword/livingword.xml",
-                    "sources":    [{ "from": "plg_task_livingword", "to": "" }],
+                    "manifest": "plg_task_livingword/livingword.xml",
+                    "sources": [
+                        {
+                            "from": "plg_task_livingword",
+                            "to": ""
+                        }
+                    ],
                     "excludeMatchMode": "strict",
-                    "excludes":   [".git", ".DS_Store", ".idea", "node_modules"]
+                    "excludes": [
+                        ".git",
+                        ".DS_Store",
+                        ".idea",
+                        "node_modules"
+                    ]
+                }
+            },
+            {
+                "type": "inline",
+                "outputName": "plg_webservices_livingword.zip",
+                "config": {
+                    "outputDir": "build/dist",
+                    "outputName": "plg_webservices_livingword-{version}.zip",
+                    "manifest": "plg_webservices_livingword/livingword.xml",
+                    "sources": [
+                        {
+                            "from": "plg_webservices_livingword",
+                            "to": ""
+                        }
+                    ],
+                    "excludeMatchMode": "strict",
+                    "excludes": [
+                        ".git",
+                        ".DS_Store",
+                        ".idea",
+                        "node_modules"
+                    ]
                 }
             },
             {
                 "type": "prebuilt",
                 "outputName": "lib_cwmscripture.zip",
-                "distGlob":   "build/vendor/lib_cwmscripture.zip"
+                "distGlob": "build/vendor/lib_cwmscripture.zip"
             },
             {
                 "type": "prebuilt",
                 "outputName": "plg_content_scripturelinks.zip",
-                "distGlob":   "build/vendor/plg_content_scripturelinks.zip"
+                "distGlob": "build/vendor/plg_content_scripturelinks.zip"
             },
             {
                 "type": "prebuilt",
                 "outputName": "plg_task_cwmscripture.zip",
-                "distGlob":   "build/vendor/plg_task_cwmscripture.zip"
+                "distGlob": "build/vendor/plg_task_cwmscripture.zip"
             }
         ],
         "verify": {
@@ -106,6 +196,7 @@
                 "packages/com_livingword.zip",
                 "packages/mod_livingword.zip",
                 "packages/plg_task_livingword.zip",
+                "packages/plg_webservices_livingword.zip",
                 "packages/lib_cwmscripture.zip",
                 "packages/plg_content_scripturelinks.zip",
                 "packages/plg_task_cwmscripture.zip"
@@ -119,7 +210,7 @@
         ]
     },
     "gitignore": {
-        "_comment": "Override the auto-derived media paths — package wrappers normally don't own a /media/ dir, but com_livingword does, and its outputs are fully generated from build/media_source/ via npm run build. Also keep build/vendor/ (scripture zips) and build/dist/ (artifact outputs) ignored.",
+        "_comment": "Override the auto-derived media paths \u2014 package wrappers normally don't own a /media/ dir, but com_livingword does, and its outputs are fully generated from build/media_source/ via npm run build. Also keep build/vendor/ (scripture zips) and build/dist/ (artifact outputs) ignored.",
         "mediaPaths": [
             "/media/com_livingword/js/",
             "/media/com_livingword/css/"
@@ -128,21 +219,35 @@
     "versionTracking": {
         "_comment": "Override the package-wrapper profile's defaults: also sync versions.json + package.json:version, and broaden substituteTokens to LivingWord's actual source roots.",
         "versionsJson": "build/versions.json",
-        "packageJson":  "package.json",
+        "packageJson": "package.json",
         "substituteTokens": {
-            "token":      "__DEPLOY_VERSION__",
-            "paths":      ["admin/", "site/", "mod_livingword/", "plg_task_livingword/"],
-            "extensions": ["php"]
+            "token": "__DEPLOY_VERSION__",
+            "paths": [
+                "admin/",
+                "site/",
+                "mod_livingword/",
+                "plg_task_livingword/",
+                "plg_webservices_livingword/"
+            ],
+            "extensions": [
+                "php"
+            ]
         }
     },
     "ars": {
         "endpoint": "https://www.christianwebministries.org",
         "categoryId": 7,
         "updateStreamId": 6,
-        "environments": ["45", "46", "48", "49", "50"],
+        "environments": [
+            "45",
+            "46",
+            "48",
+            "49",
+            "50"
+        ],
         "tokenItem": "CWM ARS API Token",
         "tokenVault": "CWM",
-        "itemDescription": "CWM LivingWord package — Bible reading plans component, daily reading module, scheduled email task plugin, plus the bundled CWM Scripture library and content plugin for in-article scripture rendering."
+        "itemDescription": "CWM LivingWord package \u2014 Bible reading plans component, daily reading module, scheduled email task plugin, plus the bundled CWM Scripture library and content plugin for in-article scripture rendering."
     },
     "github": {
         "owner": "Joomla-Bible-Study",
@@ -150,11 +255,11 @@
         "releaseBranch": "main"
     },
     "release": {
-        "_comment": "Hand-written notes lead the GitHub release body, with the generated pull-request list kept beneath. These are also what ARS republishes on the download page — the only changelog a site administrator following an update link ever sees. Use the headings cwm-changelog recognises (## New features, ## Fixes, ## Changes, ## Notes) so the same file also produces a real Joomla changelog entry instead of the install boilerplate that generated ones produced.",
+        "_comment": "Hand-written notes lead the GitHub release body, with the generated pull-request list kept beneath. These are also what ARS republishes on the download page \u2014 the only changelog a site administrator following an update link ever sees. Use the headings cwm-changelog recognises (## New features, ## Fixes, ## Changes, ## Notes) so the same file also produces a real Joomla changelog entry instead of the install boilerplate that generated ones produced.",
         "notesFile": "build/release-notes-{version}.md"
     },
     "changelog": {
         "file": "build/livingword-changelog.xml",
-        "url":  "https://raw.githubusercontent.com/Joomla-Bible-Study/CWMLivingWord/main/build/livingword-changelog.xml"
+        "url": "https://raw.githubusercontent.com/Joomla-Bible-Study/CWMLivingWord/main/build/livingword-changelog.xml"
     }
 }

--- a/livingword.xml
+++ b/livingword.xml
@@ -142,4 +142,13 @@
             <language tag="zh-CN">zh-CN/com_livingword.sys.ini</language>
         </languages>
     </administration>
+
+    <!-- Web Services API. The routes themselves are registered by
+         plg_webservices_livingword; without that plugin enabled these files
+         ship but nothing reaches them. -->
+    <api>
+        <files folder="api">
+            <folder>src</folder>
+        </files>
+    </api>
 </extension>

--- a/plg_webservices_livingword/language/en-GB/plg_webservices_livingword.ini
+++ b/plg_webservices_livingword/language/en-GB/plg_webservices_livingword.ini
@@ -1,0 +1,8 @@
+; @package    Livingword.Plugin
+; @copyright  (C) 2026 CWM Team All rights reserved
+; @license    GNU General Public License version 2 or later; see LICENSE.txt
+
+PLG_WEBSERVICES_LIVINGWORD="Web Services - LivingWord"
+PLG_WEBSERVICES_LIVINGWORD_PUBLIC_READS_LABEL="Public catalog reads"
+PLG_WEBSERVICES_LIVINGWORD_PUBLIC_READS_DESC="Allow reading plans, plan days, tools, links and groups to be read without an API token. User data — progress, notes and settings — always requires authentication and is never affected by this setting."
+PLG_WEBSERVICES_LIVINGWORD_XML_DESCRIPTION="Exposes LivingWord reading plans and per-user reading progress over the Joomla Web Services API, for mobile and third-party clients."

--- a/plg_webservices_livingword/language/en-GB/plg_webservices_livingword.sys.ini
+++ b/plg_webservices_livingword/language/en-GB/plg_webservices_livingword.sys.ini
@@ -1,0 +1,8 @@
+; @package    Livingword.Plugin
+; @copyright  (C) 2026 CWM Team All rights reserved
+; @license    GNU General Public License version 2 or later; see LICENSE.txt
+
+PLG_WEBSERVICES_LIVINGWORD="Web Services - LivingWord"
+PLG_WEBSERVICES_LIVINGWORD_PUBLIC_READS_LABEL="Public catalog reads"
+PLG_WEBSERVICES_LIVINGWORD_PUBLIC_READS_DESC="Allow reading plans, plan days, tools, links and groups to be read without an API token. User data — progress, notes and settings — always requires authentication and is never affected by this setting."
+PLG_WEBSERVICES_LIVINGWORD_XML_DESCRIPTION="Exposes LivingWord reading plans and per-user reading progress over the Joomla Web Services API, for mobile and third-party clients."

--- a/plg_webservices_livingword/livingword.xml
+++ b/plg_webservices_livingword/livingword.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="webservices" method="upgrade">
+    <name>plg_webservices_livingword</name>
+    <author>CWM Team</author>
+    <authorEmail>info@christianwebministries.org</authorEmail>
+    <authorUrl>www.christianwebministries.org</authorUrl>
+    <copyright>(C) 2026 CWM Team All rights reserved.</copyright>
+    <creationDate>2026-07-30</creationDate>
+    <version>5.7.0</version>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <description>PLG_WEBSERVICES_LIVINGWORD_XML_DESCRIPTION</description>
+    <namespace path="src">CWM\Plugin\WebServices\Livingword</namespace>
+
+    <compatibility>
+        <cms>
+            <targetplatform name="joomla" version="5[.0-9]" />
+            <targetplatform name="joomla" version="6[.0-9]" />
+        </cms>
+        <php minimum="8.3.0" />
+    </compatibility>
+
+    <files>
+        <folder plugin="livingword">services</folder>
+        <folder>src</folder>
+        <folder>language</folder>
+    </files>
+
+    <config>
+        <fields name="params">
+            <fieldset name="basic">
+                <field
+                    name="public_reads"
+                    type="radio"
+                    layout="joomla.form.field.radio.switcher"
+                    label="PLG_WEBSERVICES_LIVINGWORD_PUBLIC_READS_LABEL"
+                    description="PLG_WEBSERVICES_LIVINGWORD_PUBLIC_READS_DESC"
+                    default="0"
+                    >
+                    <option value="0">JNO</option>
+                    <option value="1">JYES</option>
+                </field>
+            </fieldset>
+        </fields>
+    </config>
+</extension>

--- a/plg_webservices_livingword/services/provider.php
+++ b/plg_webservices_livingword/services/provider.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @package    Livingword.Plugin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Plugin\WebServices\Livingword\Extension\Livingword;
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+
+return new class () implements ServiceProviderInterface {
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    public function register(Container $container): void
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $plugin = new Livingword(
+                    $container->get(DispatcherInterface::class),
+                    (array) PluginHelper::getPlugin('webservices', 'livingword')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plg_webservices_livingword/src/Extension/Livingword.php
+++ b/plg_webservices_livingword/src/Extension/Livingword.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * @package    Livingword.Plugin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Plugin\WebServices\Livingword\Extension;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Router\ApiRouter;
+use Joomla\Event\SubscriberInterface;
+use Joomla\Router\Route;
+
+/**
+ * Registers the LivingWord Web Services API routes.
+ *
+ * Two kinds of resource, with deliberately different rules.
+ *
+ * The **catalog** — plans, plan days, tools, links, groups — is content an
+ * administrator curates. It is readable and never writable over HTTP: making
+ * site content editable by API token is a different security model from the
+ * ACL and edit forms the component was built around.
+ *
+ * The **user resources** — progress, notes, settings — belong to whoever is
+ * authenticated. They are writable, because marking a reading complete is the
+ * whole point of a mobile client. They are never public: `public_reads` does
+ * not apply to them at all, since "readable without a token" and "scoped to
+ * the current user" cannot both be true.
+ *
+ * @since  5.7.0
+ */
+class Livingword extends CMSPlugin implements SubscriberInterface
+{
+    /**
+     * Catalog resources: resource => writable.
+     *
+     * All false today. The flag exists so adding a write route later is a
+     * one-line change here plus a writable controller, rather than a redesign.
+     *
+     * @var    array<string, bool>
+     * @since  5.7.0
+     */
+    private const CATALOG = [
+        'plans'    => false,
+        'plandays' => false,
+        'tools'    => false,
+        'links'    => false,
+        'groups'   => false,
+    ];
+
+    /**
+     * User-scoped resources: resource => supports a per-item route.
+     *
+     * `settings` is a singleton — a user has one settings record, so there is
+     * no id to address and no list to page through.
+     *
+     * @var    array<string, bool>
+     * @since  5.7.0
+     */
+    private const USER_RESOURCES = [
+        'progress' => true,
+        'notes'    => true,
+        'settings' => false,
+    ];
+
+    /**
+     * @return  array
+     *
+     * @since   5.7.0
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onBeforeApiRoute' => 'onBeforeApiRoute',
+        ];
+    }
+
+    /**
+     * Register the routes.
+     *
+     * This plugin being enabled IS the on/off switch; there is no separate
+     * setting. Disabled, this never runs and nothing is registered.
+     *
+     * @param   object  $event  The event.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    public function onBeforeApiRoute($event): void
+    {
+        $router = $event->getRouter();
+
+        // Catalog reads require a token unless an administrator opts into
+        // public reads. Safe by default: a site that enables the plugin
+        // without reading anything gets an authenticated API, not an open one.
+        $isPublic = (bool) $this->params->get('public_reads', 0);
+
+        foreach (self::CATALOG as $resource => $writable) {
+            $this->createReadRoutes($router, "v1/livingword/$resource", $resource, $isPublic);
+
+            if ($writable) {
+                $this->createWriteRoutes($router, "v1/livingword/$resource", $resource);
+            }
+        }
+
+        foreach (self::USER_RESOURCES as $resource => $hasItemRoute) {
+            $this->createUserRoutes($router, "v1/livingword/$resource", $resource, $hasItemRoute);
+        }
+    }
+
+    /**
+     * Catalog read routes: a list and an item.
+     *
+     * @param   ApiRouter  $router      The API router.
+     * @param   string     $baseName    Route path.
+     * @param   string     $controller  Controller name.
+     * @param   bool       $isPublic    Whether reads are allowed without a token.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    private function createReadRoutes(ApiRouter $router, string $baseName, string $controller, bool $isPublic): void
+    {
+        $defaults = [
+            'component' => 'com_livingword',
+            'public'    => $isPublic,
+        ];
+
+        $router->addRoutes([
+            new Route(['GET'], $baseName, $controller . '.displayList', [], $defaults),
+            new Route(['GET'], $baseName . '/:id', $controller . '.displayItem', ['id' => '(\d+)'], $defaults),
+        ]);
+    }
+
+    /**
+     * Catalog write routes. Unused today — see the CATALOG constant.
+     *
+     * @param   ApiRouter  $router      The API router.
+     * @param   string     $baseName    Route path.
+     * @param   string     $controller  Controller name.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    private function createWriteRoutes(ApiRouter $router, string $baseName, string $controller): void
+    {
+        $defaults = [
+            'component' => 'com_livingword',
+            'public'    => false,
+        ];
+
+        $router->addRoutes([
+            new Route(['POST'], $baseName, $controller . '.add', [], $defaults),
+            new Route(['PATCH'], $baseName . '/:id', $controller . '.edit', ['id' => '(\d+)'], $defaults),
+            new Route(['DELETE'], $baseName . '/:id', $controller . '.delete', ['id' => '(\d+)'], $defaults),
+        ]);
+    }
+
+    /**
+     * User-scoped routes. Never public, whatever `public_reads` says.
+     *
+     * @param   ApiRouter  $router        The API router.
+     * @param   string     $baseName      Route path.
+     * @param   string     $controller    Controller name.
+     * @param   bool       $hasItemRoute  Whether the resource addresses items by id.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    private function createUserRoutes(
+        ApiRouter $router,
+        string $baseName,
+        string $controller,
+        bool $hasItemRoute
+    ): void {
+        $defaults = [
+            'component' => 'com_livingword',
+            'public'    => false,
+        ];
+
+        $routes = [
+            new Route(['GET'], $baseName, $controller . '.displayList', [], $defaults),
+            new Route(['POST'], $baseName, $controller . '.add', [], $defaults),
+            new Route(['PATCH'], $baseName, $controller . '.edit', [], $defaults),
+        ];
+
+        if ($hasItemRoute) {
+            $routes[] = new Route(
+                ['GET'],
+                $baseName . '/:id',
+                $controller . '.displayItem',
+                ['id' => '(\d+)'],
+                $defaults
+            );
+            $routes[] = new Route(
+                ['DELETE'],
+                $baseName . '/:id',
+                $controller . '.delete',
+                ['id' => '(\d+)'],
+                $defaults
+            );
+        }
+
+        $router->addRoutes($routes);
+    }
+}


### PR DESCRIPTION
A Web Services API for LivingWord, for a mobile client to build against.

## Surface

**Catalog — read-only**

```
GET /v1/livingword/{plans,plandays,tools,links,groups}
GET /v1/livingword/{...}/:id
```

**User data — read and write, authenticated user only**

```
GET   /v1/livingword/progress    POST  /v1/livingword/progress
GET   /v1/livingword/notes       POST  /v1/livingword/notes
GET   /v1/livingword/settings    PATCH /v1/livingword/settings
```

Catalog controllers reuse the Administrator models, so a filter or join fixed in the backend is fixed here too. Progress, notes and settings had no models at all — only site helpers — so three Administrator ListModels were written for them.

## Authorisation is the point

Everything else here is plumbing; this is the part worth reviewing. The property is that a request reaches only the requester's own rows, and it is enforced in two places that both have to fail for it to leak:

- **The models scope themselves.** `getListQuery()` constrains `user_id` from state, defaulting to **0 — which matches nobody**. A caller that forgets to scope reads *nothing*, not everything.
- **The controller takes identity from the application and nowhere else.** No route carries a user id, no method reads one. A `user_id` sent by a client isn't ignored by policy — it is never looked at.

## Three columns are withheld at the model, not the view

`unsubscribe_token` and `action_token` are credentials: the first cancels a subscription, the second marks readings complete, both from an emailed link with no further authentication. Publishing either would hand any client that can read settings the ability to act as that user. `accountability_partner_id` names another person, whose relationship is not this endpoint's to disclose.

They are excluded from the model's `SELECT` rather than filtered in the view, so a future view that renders whatever it is given cannot leak them. The column list is positive — a column added to the table later is withheld until someone decides otherwise. Same reason `invite_token` is absent from Groups.

## Writes are per-resource, not inherited

`ApiController::add()`/`edit()` drive an `AdminModel::save()` with a form, table and bind/validate cycle. These are ListModels over rows a user accumulates by reading, and their semantics are not "save a record":

- **progress** — idempotent, so a mobile client retrying after a dropped connection isn't punished for it
- **notes** — upsert, since a user has at most one note per day; an empty note deletes, matching the site behaviour
- **settings** — an **allowlist**, so a client cannot write its own tokens or claim a reading streak it did not earn

The base class refuses any write a subclass hasn't implemented, rather than fatally calling `save()` on a model that doesn't have one.

## Read-only means read-only

The catalog is enforced twice: `plg_webservices_livingword` registers no write routes for it, and `AbstractReadOnlyController` throws `RouteNotFoundException` regardless — so a resource cannot become writable because a route was added elsewhere. `public_reads` defaults **off**, and does not apply to user data at all: "readable without a token" and "scoped to the current user" cannot both be true.

## Packaging

New extension `plg_webservices_livingword` ships as a seventh package child; the component zip carries `api/`. Build green, 52 unit tests pass, lint clean.

## Not yet verified live

No endpoint has been hit against a running site — the plugin needs registering on a dev install first. The authorisation claims above are structural, not yet demonstrated by a request, and that is exactly what should be tested before this is relied on. An API acceptance suite against the `role=test` install is the natural follow-up, mirroring Proclaim's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)