### PR TITLE
fix(api): enable the webservices plugin on install

### DIFF
--- a/build/reset-testsite.php
+++ b/build/reset-testsite.php
@@ -101,7 +101,8 @@ foreach ($installs as $install) {
     $familyWhere = "(element = 'com_livingword' AND type = 'component')
         OR (element = 'pkg_livingword' AND type = 'package')
         OR (element = 'mod_livingword' AND type = 'module')
-        OR (element = 'livingword' AND type = 'plugin' AND folder = 'task')";
+        OR (element = 'livingword' AND type = 'plugin' AND folder = 'task')
+        OR (element = 'livingword' AND type = 'plugin' AND folder = 'webservices')";
 
     if ($withScripture) {
         // element is the <libraryname>, not the folder name — see the ARS
@@ -189,6 +190,7 @@ foreach ($installs as $install) {
         'api/components/com_livingword',
         'modules/mod_livingword',
         'plugins/task/livingword',
+        'plugins/webservices/livingword',
         'media/com_livingword',
         'media/mod_livingword',
         'administrator/manifests/packages/pkg_livingword.xml',

--- a/plg_webservices_livingword/livingword.xml
+++ b/plg_webservices_livingword/livingword.xml
@@ -19,10 +19,13 @@
         <php minimum="8.3.0" />
     </compatibility>
 
+    <scriptfile>script.php</scriptfile>
+
     <files>
         <folder plugin="livingword">services</folder>
         <folder>src</folder>
         <folder>language</folder>
+        <filename>script.php</filename>
     </files>
 
     <config>

--- a/plg_webservices_livingword/script.php
+++ b/plg_webservices_livingword/script.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * @package    Livingword.Plugin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\Database\DatabaseInterface;
+
+/**
+ * Install script for plg_webservices_livingword.
+ *
+ * Enables the plugin on install, matching how the rest of the CWM family
+ * treats the plugins its packages ship — Proclaim's package script does the
+ * same through its own enablePlugin() helper, and plg_task_livingword enables
+ * itself here.
+ *
+ * What enabling does and does not open, since this one registers HTTP routes:
+ *
+ *   - Joomla's API application has to be reachable at all, which is a site
+ *     decision made before this plugin exists.
+ *   - Every route is registered with `public => false` except catalog reads,
+ *     and those only become public if an administrator switches on
+ *     `public_reads`, which defaults to off.
+ *   - So an enabled plugin on a default site serves nothing to anyone without
+ *     a Joomla API token, and tokens are created per user, deliberately.
+ *
+ * The opt-in therefore sits at the token, not at the plugin. Leaving the
+ * plugin disabled instead would mean the API silently 404s for a site that
+ * created a token and expected it to work — a worse failure, because nothing
+ * says why.
+ *
+ * @since  5.7.0
+ */
+return new class () implements \Joomla\CMS\Installer\InstallerScriptInterface {
+    /**
+     * @param   InstallerAdapter  $adapter  The adapter calling this method
+     *
+     * @return  bool
+     *
+     * @since   5.7.0
+     */
+    public function install(InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param   InstallerAdapter  $adapter  The adapter calling this method
+     *
+     * @return  bool
+     *
+     * @since   5.7.0
+     */
+    public function update(InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param   InstallerAdapter  $adapter  The adapter calling this method
+     *
+     * @return  bool
+     *
+     * @since   5.7.0
+     */
+    public function uninstall(InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param   string            $route    install | update | uninstall
+     * @param   InstallerAdapter  $adapter  The adapter calling this method
+     *
+     * @return  bool
+     *
+     * @since   5.7.0
+     */
+    public function preflight(string $route, InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * Enable the plugin on a fresh install.
+     *
+     * Install route only. An administrator who turns the API off afterwards
+     * means it, and an update must not quietly switch it back on.
+     *
+     * @param   string            $route    install | update | uninstall
+     * @param   InstallerAdapter  $adapter  The adapter calling this method
+     *
+     * @return  bool
+     *
+     * @since   5.7.0
+     */
+    public function postflight(string $route, InstallerAdapter $adapter): bool
+    {
+        if ($route !== 'install') {
+            return true;
+        }
+
+        try {
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+            $query = $db->getQuery(true)
+                ->update($db->quoteName('#__extensions'))
+                ->set($db->quoteName('enabled') . ' = 1')
+                ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+                ->where($db->quoteName('folder') . ' = ' . $db->quote('webservices'))
+                ->where($db->quoteName('element') . ' = ' . $db->quote('livingword'))
+                ->where($db->quoteName('enabled') . ' = 0');
+
+            $db->setQuery($query)->execute();
+
+            if ($db->getAffectedRows() > 0) {
+                Factory::getApplication()->enqueueMessage(
+                    'The LivingWord Web Services plugin has been enabled. The API still requires a'
+                    . ' Joomla API token; catalog reads stay private unless you switch on'
+                    . ' "Public catalog reads" in the plugin options.',
+                    'info'
+                );
+            }
+        } catch (\Throwable $e) {
+            Factory::getApplication()->enqueueMessage(
+                'CWM LivingWord: could not enable the Web Services plugin — ' . $e->getMessage()
+                . ' Enable it manually under System → Plugins.',
+                'warning'
+            );
+        }
+
+        return true;
+    }
+};


### PR DESCRIPTION
Follow-up to #113, which turned the release gate red:

```
DRIFT:  plg_webservices_livingword — needs enabled = 1
RELEASE GATE FAILED: clean install
```

Joomla registers new plugins disabled, so the API shipped installed but not serving.

## Enabling on install

Matches how the CWM family treats the plugins its packages ship — Proclaim's package script does this through its own `enablePlugin()` helper, and `plg_task_livingword` enables itself.

I paused on this one because unlike the task plugin, **this registers HTTP routes**, and turning on a network surface by default deserves an argument rather than a convention. The argument:

- Joomla's API application has to be reachable at all, which is a site decision made before this plugin exists
- Every route is registered `public => false` except catalog reads
- Those only become public if an administrator switches on `public_reads`, which **defaults to off**

So an enabled plugin on a default site serves nothing to anyone without a Joomla API token, and tokens are created per user, deliberately. **The opt-in sits at the token, not the plugin.** Leaving it disabled means the API silently 404s for a site that created a token and expected it to work — the worse failure, because nothing says why.

Install route only: an administrator who turns the API off afterwards means it, and an update must not quietly switch it back on.

## The reset script was the actual bug

The first attempt at this fix appeared not to work — the plugin stayed disabled. It wasn't the install script:

`build/reset-testsite.php` was written before this plugin existed and cleared only `plugin/task/livingword`. The stale `plugin/webservices/livingword` row meant the next package install routed to **update()** rather than install(), so the install-only postflight correctly declined. The plugin looked broken when the teardown was what was incomplete.

Same omission as the `api/` directory in #100. The teardown has to know about every extension the package ships, or the next install silently tests the wrong path — and "silently tests the wrong path" is indistinguishable from passing.

## Verified

```
Summary: 3 OK, 0 fixed, 0 errors
Schema verified for 5.6.0.
CLEAN-INSTALL TEST PASSED
22 passed  (accessibility)
RELEASE GATE PASSED
```

All three extensions now register and enable, including the new plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)