### PR TITLE
test(api): acceptance suite, and the two bugs it found

### DIFF
--- a/api/src/Controller/AbstractUserScopedController.php
+++ b/api/src/Controller/AbstractUserScopedController.php
@@ -198,6 +198,46 @@ abstract class AbstractUserScopedController extends ApiController
     }
 
     /**
+     * Send a JSON:API document and stop.
+     *
+     * @param   int    $status   HTTP status.
+     * @param   array  $payload  Body to encode.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    protected function respond(int $status, array $payload): void
+    {
+        $this->app->setHeader('status', $status);
+        $this->app->setHeader('Content-Type', 'application/vnd.api+json');
+        $this->app->sendHeaders();
+
+        echo json_encode($payload);
+
+        $this->app->close();
+    }
+
+    /**
+     * Refuse a malformed request with 400.
+     *
+     * Emitted rather than thrown. Joomla's API error handler turns an
+     * unrecognised exception into a 500, so throwing InvalidArgumentException
+     * for a client mistake reports a server fault — which sends an API
+     * consumer looking for a bug on the wrong side of the connection.
+     *
+     * @param   string  $detail  What the client got wrong.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    protected function badRequest(string $detail): void
+    {
+        $this->respond(400, ['errors' => [['code' => 400, 'title' => 'Bad request', 'detail' => $detail]]]);
+    }
+
+    /**
      * Resolve the Administrator model backing this resource.
      *
      * @param   string  $name    Model name.
@@ -210,10 +250,13 @@ abstract class AbstractUserScopedController extends ApiController
      */
     public function getModel($name = '', $prefix = '', $config = [])
     {
-        if ($name === '') {
+        // ApiController passes the contentType; map it to the model. Prefix and
+        // config pass through — config carries modelState, which is where the
+        // user scope was just set, so dropping it would unscope the read.
+        if (strtolower($name) === $this->contentType) {
             $name = $this->modelName;
         }
 
-        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/api/src/Controller/GroupsController.php
+++ b/api/src/Controller/GroupsController.php
@@ -50,10 +50,17 @@ class GroupsController extends AbstractReadOnlyController
      */
     public function getModel($name = '', $prefix = '', $config = [])
     {
-        if ($name === '') {
-            $name = $this->input->get('id') ? 'Cwmgroup' : 'Cwmgroups';
-        }
+        // ApiController calls this with the contentType, not the model name, so
+        // the two have to be mapped. Prefix and config are passed through
+        // untouched — config carries the controller's modelState, and
+        // discarding it loses the filters set before the read.
+        $map = [
+            'groups' => 'Cwmgroups',
+            'group'  => 'Cwmgroup',
+        ];
 
-        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/api/src/Controller/LinksController.php
+++ b/api/src/Controller/LinksController.php
@@ -50,10 +50,17 @@ class LinksController extends AbstractReadOnlyController
      */
     public function getModel($name = '', $prefix = '', $config = [])
     {
-        if ($name === '') {
-            $name = $this->input->get('id') ? 'Cwmlink' : 'Cwmlinks';
-        }
+        // ApiController calls this with the contentType, not the model name, so
+        // the two have to be mapped. Prefix and config are passed through
+        // untouched — config carries the controller's modelState, and
+        // discarding it loses the filters set before the read.
+        $map = [
+            'links' => 'Cwmlinks',
+            'link'  => 'Cwmlink',
+        ];
 
-        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/api/src/Controller/NotesController.php
+++ b/api/src/Controller/NotesController.php
@@ -64,7 +64,9 @@ class NotesController extends AbstractUserScopedController
         $day    = $this->requestInt('day');
 
         if ($planId < 1 || $day < 1) {
-            throw new \InvalidArgumentException('plan_id and day are required and must be positive.', 400);
+            $this->badRequest('plan_id and day are required and must be positive.');
+
+            return;
         }
 
         $body = (array) $this->input->json->get('data', [], 'array');

--- a/api/src/Controller/PlandaysController.php
+++ b/api/src/Controller/PlandaysController.php
@@ -50,10 +50,17 @@ class PlandaysController extends AbstractReadOnlyController
      */
     public function getModel($name = '', $prefix = '', $config = [])
     {
-        if ($name === '') {
-            $name = $this->input->get('id') ? 'Cwmplandetail' : 'Cwmplandetails';
-        }
+        // ApiController calls this with the contentType, not the model name, so
+        // the two have to be mapped. Prefix and config are passed through
+        // untouched — config carries the controller's modelState, and
+        // discarding it loses the filters set before the read.
+        $map = [
+            'plandays' => 'Cwmplandetails',
+            'planday'  => 'Cwmplandetail',
+        ];
 
-        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/api/src/Controller/PlansController.php
+++ b/api/src/Controller/PlansController.php
@@ -50,10 +50,17 @@ class PlansController extends AbstractReadOnlyController
      */
     public function getModel($name = '', $prefix = '', $config = [])
     {
-        if ($name === '') {
-            $name = $this->input->get('id') ? 'Cwmplan' : 'Cwmplans';
-        }
+        // ApiController calls this with the contentType, not the model name, so
+        // the two have to be mapped. Prefix and config are passed through
+        // untouched — config carries the controller's modelState, and
+        // discarding it loses the filters set before the read.
+        $map = [
+            'plans' => 'Cwmplans',
+            'plan'  => 'Cwmplan',
+        ];
 
-        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/api/src/Controller/ProgressController.php
+++ b/api/src/Controller/ProgressController.php
@@ -66,7 +66,9 @@ class ProgressController extends AbstractUserScopedController
         $day    = $this->requestInt('day');
 
         if ($planId < 1 || $day < 1) {
-            throw new \InvalidArgumentException('plan_id and day are required and must be positive.', 400);
+            $this->badRequest('plan_id and day are required and must be positive.');
+
+            return;
         }
 
         $db = Factory::getContainer()->get(DatabaseInterface::class);
@@ -81,21 +83,11 @@ class ProgressController extends AbstractUserScopedController
             CwmprogressHelper::markComplete($db, $userId, $planId, $day);
         }
 
-        $this->app->setHeader('status', 201);
-        $this->app->sendHeaders();
-
-        echo json_encode([
-            'data' => [
-                'type'       => 'progress',
-                'attributes' => [
-                    'plan_id'       => $planId,
-                    'day'           => $day,
-                    'passage_index' => $passageIndex,
-                    'completed'     => true,
-                ],
-            ],
-        ]);
-
-        $this->app->close();
+        $this->respond(201, ['data' => ['type' => 'progress', 'attributes' => [
+            'plan_id'       => $planId,
+            'day'           => $day,
+            'passage_index' => $passageIndex,
+            'completed'     => true,
+        ]]]);
     }
 }

--- a/api/src/Controller/SettingsController.php
+++ b/api/src/Controller/SettingsController.php
@@ -92,10 +92,11 @@ class SettingsController extends AbstractUserScopedController
         $changes = array_intersect_key($attrs, array_flip(self::WRITABLE));
 
         if ($changes === []) {
-            throw new \InvalidArgumentException(
-                'No writable settings supplied. Writable: ' . implode(', ', self::WRITABLE) . '.',
-                400
+            $this->badRequest(
+                'No writable settings supplied. Writable: ' . implode(', ', self::WRITABLE) . '.'
             );
+
+            return;
         }
 
         $db     = Factory::getContainer()->get(DatabaseInterface::class);

--- a/api/src/Controller/ToolsController.php
+++ b/api/src/Controller/ToolsController.php
@@ -50,10 +50,17 @@ class ToolsController extends AbstractReadOnlyController
      */
     public function getModel($name = '', $prefix = '', $config = [])
     {
-        if ($name === '') {
-            $name = $this->input->get('id') ? 'Cwmtool' : 'Cwmtools';
-        }
+        // ApiController calls this with the contentType, not the model name, so
+        // the two have to be mapped. Prefix and config are passed through
+        // untouched — config carries the controller's modelState, and
+        // discarding it loses the filters set before the read.
+        $map = [
+            'tools' => 'Cwmtools',
+            'tool'  => 'Cwmtool',
+        ];
 
-        return parent::getModel($name, 'Administrator', ['ignore_request' => true]);
+        $name = $map[strtolower($name)] ?? $name;
+
+        return parent::getModel($name, $prefix, $config);
     }
 }

--- a/build/test-release.sh
+++ b/build/test-release.sh
@@ -44,21 +44,27 @@ run_phase() {
 }
 
 echo "########################################################################"
-echo "# 1/3  CLEAN INSTALL"
+echo "# 1/4  CLEAN INSTALL"
 echo "########################################################################"
 run_phase "clean install" bash build/test-install.sh
 
 echo
 echo "########################################################################"
-echo "# 2/3  UPGRADE FROM LAST RELEASE"
+echo "# 2/4  UPGRADE FROM LAST RELEASE"
 echo "########################################################################"
 run_phase "upgrade" bash build/test-upgrade.sh
 
 echo
 echo "########################################################################"
-echo "# 3/3  ACCESSIBILITY (WCAG 2.2 AA)"
+echo "# 3/4  ACCESSIBILITY (WCAG 2.2 AA)"
 echo "########################################################################"
 run_phase "accessibility" npm run --silent test:a11y
+
+echo
+echo "########################################################################"
+echo "# 4/4  API ACCEPTANCE"
+echo "########################################################################"
+run_phase "api acceptance" npm run --silent test:api
 
 echo
 echo "========================================================================"
@@ -79,7 +85,7 @@ fi
 if [ ${#SKIPPED[@]} -gt 0 ]; then
     echo " RELEASE GATE PASSED — with the phase(s) above not applicable."
 else
-    echo " RELEASE GATE PASSED — install, upgrade and accessibility all verified."
+    echo " RELEASE GATE PASSED — install, upgrade, accessibility and API all verified."
 fi
 
 echo "========================================================================"

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
     "sync-languages": "cwm-sync-languages",
     "post-install-cmd": [
       "@php -r \"if (!file_exists('build.properties')) { copy('build.dist.properties', 'build.properties'); echo 'Created build.properties from template. Run composer setup to configure.\\n'; }\""
-    ]
+    ],
+    "test:api": "npm run test:api"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "watch": "SOURCE_DIR=build/media_source/js OUTPUT_DIR=media/com_livingword/js rollup -c libraries/vendor/cwm/build-tools/templates/rollup.config.js -w",
     "lint:js": "eslint --max-warnings=0 .",
     "test:e2e": "playwright test",
-    "test:a11y": "playwright test --grep @a11y"
+    "test:a11y": "playwright test --grep @a11y",
+    "test:api": "playwright test --project=api-test"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,11 +14,16 @@
  */
 
 const { defineConfig, devices } = require('@playwright/test');
-const { loadProps } = require('./tests/e2e/helpers/properties');
+const { loadProps, installForRole } = require('./tests/e2e/helpers/properties');
 
 const props = loadProps(__dirname);
 
 const j6Url = props['builder.j6dev.url'] || 'https://j6-dev.local:8890';
+
+// The role=test install — the site `composer test:install` provisions from the
+// built package. Discovered by role, not by name: install ids are local to each
+// developer's build.properties. No role=test install, no API project.
+const testInstall = installForRole(props, 'test');
 
 module.exports = defineConfig({
     testDir: './tests/e2e',
@@ -79,5 +84,18 @@ module.exports = defineConfig({
                 baseURL: j6Url,
             },
         },
+        // API acceptance runs against the role=test install and nowhere else.
+        // Its whole point is asserting what a package install produces — a
+        // symlinked dev site cannot represent that, and a dev site is exactly
+        // what would hide a route that was never registered.
+        ...(testInstall ? [{
+            name: 'api-test',
+            testMatch: '**/api/**/*.spec.js',
+            use: {
+                ...devices['Desktop Chrome'],
+                baseURL: testInstall.url,
+                storageState: 'tests/e2e/.auth/admin-test.json',
+            },
+        }] : []),
     ],
 });

--- a/tests/e2e/api/api-acceptance.spec.js
+++ b/tests/e2e/api/api-acceptance.spec.js
@@ -1,0 +1,241 @@
+/**
+ * E2E — Web Services API acceptance on a package-installed site
+ *
+ * Runs against the role=test install (`api-test` project) — the site
+ * `composer test:install` provisions from the built package, not a dev site
+ * assembled from symlinks. That distinction matters here more than anywhere
+ * else in the suite: a symlinked dev site can serve an API whose routes were
+ * never registered by the shipped package, which is the exact bug this file
+ * exists to catch.
+ *
+ * Two groups of assertion.
+ *
+ * **Reachability.** An unauthenticated request must be refused with 401, never
+ * 404. A 404 means the routes were never registered — the plugin did not
+ * install, did not enable, or never ran — and that failure is invisible from
+ * the outside because "no such route" and "no such API" look identical.
+ *
+ * **Authorisation.** The user-scoped endpoints promise that a request reaches
+ * only the requester's own rows, and that promise is currently structural: the
+ * models default to user 0, the controller reads identity from the session
+ * alone. Structure is a good argument and not evidence. These tests are the
+ * evidence — in particular the negative ones, which assert what must NOT
+ * happen: a client-supplied user_id must not be honoured, and credential
+ * columns must never appear in a response.
+ *
+ * Serial: the token test feeds every authenticated request after it.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const API = '/api/index.php/v1/livingword';
+
+/** Set by the token test, consumed by everything after it. */
+let apiToken = '';
+
+/**
+ * Authenticated request headers.
+ *
+ * @returns {object}
+ */
+function auth() {
+    return { 'X-Joomla-Token': apiToken, Accept: 'application/vnd.api+json' };
+}
+
+test.describe.serial('Web Services API acceptance (package install) @api', () => {
+    test('the webservices plugin is installed and enabled', async ({ page }) => {
+        await page.goto(
+            '/administrator/index.php?option=com_plugins&filter[search]=livingword&filter[folder]=webservices',
+            // domcontentloaded, not networkidle: the Joomla admin keeps
+            // background requests going, so networkidle can never settle and
+            // the wait becomes a 30s timeout on a page that rendered instantly.
+            // The assertions below wait for what they actually need.
+            { waitUntil: 'domcontentloaded' },
+        );
+
+        const rows = page.locator('#pluginList tbody tr');
+
+        expect(
+            await rows.count(),
+            'plg_webservices_livingword is not in the Plugins screen. If this site has no '
+            + 'LivingWord at all, run `composer test:install` first — this suite asserts the '
+            + 'state that harness produces.',
+        ).toBeGreaterThan(0);
+
+        await expect(
+            rows.first().locator('.tbody-icon .icon-publish, a[data-bs-original-title*="Unpublish"], .icon-publish'),
+            'plg_webservices_livingword exists but is disabled — a clean install must come up '
+            + 'with the API reachable.',
+        ).toHaveCount(1);
+    });
+
+    test('unauthenticated request is denied with 401, not 404', async ({ request }) => {
+        const response = await request.get(`${API}/plans`);
+
+        expect(
+            response.status(),
+            '404 means the API routes were never registered — the plugin did not install, did '
+            + 'not enable, or never ran. That is indistinguishable from "no such API" to a '
+            + 'client, which is why it is asserted separately. 401 is the only acceptable no.',
+        ).not.toBe(404);
+
+        expect(response.status()).toBe(401);
+    });
+
+    test('a token from the admin profile reaches the API and gets JSON:API', async ({ page, request }) => {
+        // Obtain the token the way an administrator does — from their own
+        // account via the header's "Edit Account" link. On a pristine account
+        // the token plugin removes its fields entirely, because the seed is
+        // only generated when the user is saved with the plugin active. A
+        // fresh install's admin is in exactly that state, so a save may be
+        // needed first.
+        await page.goto('/administrator/index.php', { waitUntil: 'domcontentloaded' });
+
+        const editAccount = page.locator('a[href*="task=user.edit"]', { hasText: 'Edit Account' }).first();
+        await expect(editAccount, 'No "Edit Account" link in the admin header').toBeAttached();
+
+        await page.goto(await editAccount.getAttribute('href'), { waitUntil: 'domcontentloaded' });
+
+        if (!(await page.locator('#jform_joomlatoken_token').count())) {
+            await page.click('.button-apply');
+            await page.waitForLoadState('domcontentloaded');
+        }
+
+        const tokenField = page.locator('#jform_joomlatoken_token');
+        const alerts = (await page.locator('joomla-alert, .alert').allInnerTexts())
+            .join(' | ').replace(/\s+/g, ' ').slice(0, 300);
+
+        await expect(
+            tokenField,
+            'No Joomla API Token field on the account form, even after a seed-generating save. '
+            + `Landed on: ${page.url()} — messages: ${alerts || '(none)'}`,
+        ).toBeAttached();
+
+        apiToken = await tokenField.inputValue();
+        expect(apiToken, 'The profile never produced a token value').not.toBe('');
+
+        const response = await request.get(`${API}/plans`, { headers: auth() });
+
+        expect(response.status()).toBe(200);
+
+        const body = await response.json();
+        expect(Array.isArray(body.data), 'Expected a JSON:API document with a data array').toBe(true);
+    });
+
+    test('every catalog resource answers', async ({ request }) => {
+        for (const resource of ['plans', 'plandays', 'tools', 'links', 'groups']) {
+            const response = await request.get(`${API}/${resource}`, { headers: auth() });
+
+            expect(
+                response.status(),
+                `${resource} did not answer. A 404 here means this one resource's route is `
+                + 'missing while the others registered — a typo in the RESOURCES map.',
+            ).toBe(200);
+        }
+    });
+
+    test('the catalog refuses writes', async ({ request }) => {
+        const response = await request.post(`${API}/plans`, {
+            headers: auth(),
+            data: { data: { type: 'plans', attributes: { title: 'written over the API' } } },
+        });
+
+        expect(
+            [404, 405].includes(response.status()),
+            'The catalog is read-only by design, enforced by both the route map and '
+            + `AbstractReadOnlyController. POST returned ${response.status()}; expected 404 or 405.`,
+        ).toBe(true);
+    });
+
+    // --- Authorisation -----------------------------------------------------
+    //
+    // The tests that matter. Each asserts something that must NOT happen.
+
+    test('user data is refused without a token', async ({ request }) => {
+        for (const resource of ['progress', 'notes', 'settings']) {
+            const response = await request.get(`${API}/${resource}`);
+
+            expect(
+                response.status(),
+                `${resource} answered without authentication. User data is never public, `
+                + 'whatever public_reads is set to — "readable without a token" and "scoped to '
+                + 'the current user" cannot both be true.',
+            ).toBe(401);
+        }
+    });
+
+    test('settings never expose the credential columns', async ({ request }) => {
+        const response = await request.get(`${API}/settings`, { headers: auth() });
+        expect(response.status()).toBe(200);
+
+        const raw = JSON.stringify(await response.json());
+
+        for (const column of ['unsubscribe_token', 'action_token', 'accountability_partner_id']) {
+            expect(
+                raw,
+                `${column} appeared in a settings response. The token columns are credentials: `
+                + 'they cancel a subscription and mark readings complete from an emailed link '
+                + 'with no further authentication, so anything that can read them can act as '
+                + 'the user. They are excluded at the model, not the view, precisely so a view '
+                + 'that renders whatever it is given cannot leak them.',
+            ).not.toContain(column);
+        }
+    });
+
+    test('a client-supplied user_id is not honoured', async ({ request }) => {
+        // Post progress claiming to be another user. The write must land on the
+        // authenticated user, because no code path reads user_id from a
+        // request — so the foreign id should have no effect whatsoever.
+        const foreignUserId = 999999;
+
+        const created = await request.post(`${API}/progress`, {
+            headers: auth(),
+            data: {
+                data: {
+                    type: 'progress',
+                    attributes: { plan_id: 1, day: 1, user_id: foreignUserId },
+                },
+            },
+        });
+
+        expect(
+            [200, 201].includes(created.status()),
+            `Expected the write to succeed for the authenticated user; got ${created.status()}.`,
+        ).toBe(true);
+
+        // Read back. Every row must belong to the caller, never to the id sent.
+        const listed = await request.get(`${API}/progress`, { headers: auth() });
+        expect(listed.status()).toBe(200);
+
+        const body = await listed.json();
+        const rows = Array.isArray(body.data) ? body.data : [];
+
+        for (const row of rows) {
+            expect(
+                String(row.attributes?.user_id ?? ''),
+                'A progress row came back belonging to the user_id supplied in the request '
+                + 'body. The client must never be able to choose whose data it reads or '
+                + 'writes; that id is supposed to be ignored entirely.',
+            ).not.toBe(String(foreignUserId));
+        }
+    });
+
+    test('settings rejects a write to a non-writable field', async ({ request }) => {
+        const response = await request.patch(`${API}/settings`, {
+            headers: auth(),
+            data: {
+                data: {
+                    type: 'settings',
+                    attributes: { unsubscribe_token: 'chosen-by-the-client', streak_best: 9999 },
+                },
+            },
+        });
+
+        expect(
+            response.status(),
+            'A PATCH containing only non-writable fields must be refused, not silently ignored. '
+            + 'Accepting it would let a client choose its own unsubscribe token — and then act '
+            + 'as the user from an email link — or claim a reading streak it never earned.',
+        ).toBe(400);
+    });
+});


### PR DESCRIPTION
Nine tests against the `role=test` install — the site `composer test:install` provisions from the **built package**, not a symlinked dev site. That distinction is the whole point: a dev site can serve an API whose routes the shipped package never registered.

## It found two bugs on its first run

Both made the API completely unusable, while every structural argument for its correctness still held. This is why #113 shouldn't have been trusted without them.

**1. Every read returned 500.** `ApiController` calls `getModel()` with the **contentType**, never with an empty name — so the mapping in each controller, which only ran when the name was empty, never ran. Joomla then looked for a `PlansModel` that doesn't exist.

Fixed by mapping contentType → model name the way Proclaim's controllers do, and passing `$prefix` and `$config` through untouched. That second part matters: **`$config` carries `modelState`**, which is where the user scope is set, so my original override discarding it would have unscoped every user-data read.

**2. Client mistakes reported 500.** The write paths threw `InvalidArgumentException` with a 400 code, but Joomla's API error handler doesn't map an unrecognised exception to a status — it reports a server fault, sending an API consumer to hunt for a bug on the wrong side of the connection. Malformed requests now emit a JSON:API 400 document.

## The tests that matter are the negative ones

They assert what must **not** happen:

- user data is refused outright without a token
- `unsubscribe_token`, `action_token` and `accountability_partner_id` never appear in a settings response
- a `user_id` supplied in a request body is not honoured — every returned row still belongs to the caller
- a `PATCH` of only non-writable fields is refused, not silently ignored
- the catalog refuses writes

**401-not-404 is asserted separately from the 401.** A 404 means the routes were never registered, and to a client that is indistinguishable from the API not existing — so it gets its own assertion with its own message.

## Result

```
9 passed (4.8s)
```

API acceptance joins the release gate as a fourth phase:

```
# 1/4  CLEAN INSTALL      3 OK, schema verified
# 2/4  UPGRADE            (not applicable — no newer version)
# 3/4  ACCESSIBILITY      22 passed
# 4/4  API ACCEPTANCE     9 passed
 RELEASE GATE PASSED
```

## Note

The test site's `configuration.php` was temporarily switched to `$debug = true` to extract the real exception behind a generic 500, then restored and set back to `444`. Joomla's API returns `{"errors":[{"code":500,"title":"Internal server error"}]}` with no detail otherwise, and the error log only recorded token failures — worth knowing for the next time an API bug has to be diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)