### PR TITLE
fix(scripture): resolve books through the library's public API, register as a consumer

### DIFF
--- a/script.php
+++ b/script.php
@@ -12,6 +12,7 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Library\Scripture\Installer\ConsumerRegistry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Installer\InstallerAdapter;
@@ -68,6 +69,8 @@ class Com_livingwordInstallerScript
      */
     public function uninstall(InstallerAdapter $adapter): bool
     {
+        $this->unregisterScriptureConsumer();
+
         return true;
     }
 
@@ -144,6 +147,10 @@ class Com_livingwordInstallerScript
 
             $this->ensureActionTokenIndex();
 
+            // Tell lib_cwmscripture this component depends on it, so removing
+            // the library is refused while Living Word is installed.
+            $this->registerScriptureConsumer();
+
             Factory::getApplication()->enqueueMessage(
                 sprintf('CWM LivingWord %s has been installed successfully.', $version),
                 'message'
@@ -165,6 +172,10 @@ class Com_livingwordInstallerScript
 
             $this->ensureActionTokenIndex();
 
+            // Idempotent, and the repair path for a fresh package install where
+            // the library child had not been stored yet at our postflight.
+            $this->registerScriptureConsumer();
+
             Factory::getApplication()->enqueueMessage(
                 sprintf('CWM LivingWord has been updated to version %s.', $version),
                 'message'
@@ -172,6 +183,54 @@ class Com_livingwordInstallerScript
         }
 
         return true;
+    }
+
+    /**
+     * Register com_livingword as a consumer of lib_cwmscripture.
+     *
+     * The library gates two destructive operations on "who still depends on
+     * me": its own uninstall, and dropping the shared `#__bsms_*` tables, which
+     * hold every locally downloaded translation. Joomla tracks no library
+     * dependencies, so the only extensions the library can see are the ones in
+     * its `FIRST_PARTY` list or in this registry. com_livingword is currently in
+     * that hardcoded list; registering means we no longer depend on staying
+     * there. Requires lib_cwmscripture 1.1.6 (#85).
+     *
+     * The library is a soft dependency — every call site guards on
+     * `class_exists()` / `isInstalled()` and falls back to BibleGateway — so a
+     * missing registry must never fail the install.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    private function registerScriptureConsumer(): void
+    {
+        if (!class_exists(ConsumerRegistry::class)) {
+            return;
+        }
+
+        ConsumerRegistry::register('com_livingword', 'component', name: 'Living Word (com_livingword)');
+    }
+
+    /**
+     * Drop this component's row from the library's consumer registry.
+     *
+     * Leaving it behind would not pin the library forever — `installed()` prunes
+     * rows whose extension is gone from `#__extensions` — but unregistering is
+     * the cheap, explicit half of the contract.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    private function unregisterScriptureConsumer(): void
+    {
+        if (!class_exists(ConsumerRegistry::class)) {
+            return;
+        }
+
+        ConsumerRegistry::unregister('com_livingword', 'component');
     }
 
     /**

--- a/site/src/Helper/CwmscriptureHelper.php
+++ b/site/src/Helper/CwmscriptureHelper.php
@@ -404,6 +404,16 @@ class CwmscriptureHelper
      * Handles formats like "Genesis 1", "Genesis 1-3", "John 3:16-18",
      * "1 Samuel 2:1-10".
      *
+     * Book resolution is the library's job, via the public
+     * `AbstractBibleProvider::resolveBookCode()`. This used to walk
+     * `AbstractBibleProvider::BOOK_NAMES` by reflection, which read a
+     * `protected` constant the library never promised to keep — lib 1.1.13
+     * moves it into `Book\BookCodes`, at which point `getConstant()` returns
+     * false, the name table is empty, and every lookup silently returns null
+     * (#118). `resolveBookCode()` also resolves translated names and
+     * abbreviations, and returns '' rather than guessing when an abbreviation
+     * prefixes more than one book — "Jo" no longer answers Joshua for John.
+     *
      * @param   string  $reference  Human-readable passage reference
      *
      * @return  ?array{book: string, chapter: int}  Parsed result or null
@@ -422,31 +432,13 @@ class CwmscriptureHelper
         $bookName = trim($m[1]);
         $chapter  = (int) $m[2];
 
-        // Use BibleBrainProvider's USFM code mapping
-        $usfmCodes = \CWM\Library\Scripture\Bible\Provider\BibleBrainProvider::getUsfmCodes();
-        $bookNames = \CWM\Library\Scripture\Bible\AbstractBibleProvider::BOOK_NAMES ?? [];
+        $usfmCode = \CWM\Library\Scripture\Bible\AbstractBibleProvider::resolveBookCode($bookName);
 
-        // Try reflection to access BOOK_NAMES constant
-        try {
-            $reflection = new \ReflectionClass(\CWM\Library\Scripture\Bible\AbstractBibleProvider::class);
-            $bookNames  = $reflection->getConstant('BOOK_NAMES') ?: [];
-        } catch (\ReflectionException) {
+        if ($usfmCode === '') {
             return null;
         }
 
-        $normalized = strtolower($bookName);
-
-        foreach ($bookNames as $num => $name) {
-            if (strtolower($name) === $normalized || str_starts_with(strtolower($name), $normalized)) {
-                $usfmCode = $usfmCodes[$num] ?? '';
-
-                if (!empty($usfmCode)) {
-                    return ['book' => $usfmCode, 'chapter' => $chapter];
-                }
-            }
-        }
-
-        return null;
+        return ['book' => $usfmCode, 'chapter' => $chapter];
     }
 
     /**


### PR DESCRIPTION
Closes #118, closes #85. Both are the same coupling problem with `lib_cwmscripture`, in the same two files, so they land together.

## #118 — the reflection into `BOOK_NAMES`

`CwmscriptureHelper::parsePassageReference()` read `AbstractBibleProvider::BOOK_NAMES` by reflection. lib PR #50 moves that `protected` constant into `Book\BookCodes`, so on lib 1.1.13 `getConstant()` returns `false`, `?: []` makes it an empty table, the loop matches nothing, and the audio book lookup returns null with no error and no log.

**The fix is not the one the issue proposed.** #118 asked for a new `AbstractBibleProvider::bookNames()` delegate in the library plus a `method_exists()` shim here. That turns out to be unnecessary: **`AbstractBibleProvider::resolveBookCode()` is already public**, exists in every lib from 1.1.11 on, returns codes from the same table `getUsfmCodes()` exposes, and does the entire job of the hand-rolled loop. So:

- no library change is needed, and the "library gap" #118 describes is already closed on lib `main` (`BookCodes::names()` is public, `BookCodes::BOOK_NAMES` is a public const);
- no capability detection is needed — the same call works against the shipped 1.1.12 and against 1.1.13;
- the dead line 427 (`AbstractBibleProvider::BOOK_NAMES ?? []`, an `Error` on a protected constant, immediately overwritten) is gone.

Two behaviour changes come with it, both improvements:

| | before | after |
|---|---|---|
| Translated book names ("Žalm", "Juan") | no match | resolved via `ScriptureHelper` (lib #1688) |
| Abbreviations (187-entry table) | no match | resolved |
| Ambiguous prefix ("Jo") | first in table order → **Joshua** | no match, rather than a wrong guess |

The ambiguity change is deliberate on the library's side (lib #1688: "Jo" silently resolved to Joshua and never John).

## #85 — `ConsumerRegistry` registration

The library gates its own uninstall, and the drop of the shared `#__bsms_*` tables that hold every locally downloaded translation, on who still depends on it. Joomla tracks no library dependencies, so today that protection rests entirely on `com_livingword` being hardcoded in the library's `FIRST_PARTY` list. This registers explicitly so it no longer has to be.

- `register()` in `postflight` on **both** the install and update routes. The library ships as a package child listed ahead of the component in `pkg_livingword.xml`, but if its namespace is not autoloadable yet at our postflight, the next update repairs the row. `register()` is idempotent.
- `unregister()` in `uninstall()`.
- Both guarded on `class_exists()` — the library is a soft dependency here, with a BibleGateway fallback at every call site, so a missing registry must never fail an install.

Note that lib 1.1.7's `ConsumerScanner` also backfills consumers by scanning disk for the `CWM\Library\Scripture` namespace, so the uninstall guard is belt-and-braces either way.

## Verification

- Simulated both branches of `resolveBookCode()` — `ScriptureHelper::getBookNumber()`'s 187-entry abbreviation table first, then the English `BOOK_NAMES` exact/unique-prefix fallback — over every seeded reading in `install.mysql.utf8.sql`. **381 references, 53 distinct books; all 53 resolve, all via the abbreviation branch, and every one yields the identical USFM code the old loop produced. Zero mismatches.** (The translated-name map is the one part not exercised: it needs Joomla runtime, and on an English site it is consulted only after the abbreviation table misses — which never happened here.)
- The three comma-list references (`Genesis 24,26`, `Psalm 1,8,19,...`, `1 Kings 3,6-12`) fail the reference regex before this change and after it — unchanged, not a regression.
- No test stubbed the old reflection path; nothing else in the component reaches into the library by reflection or for a protected member (grepped).
- `composer lint:syntax`, `composer lint` (0 of 97 fixable), `composer test` (52 tests, 71 assertions) — all pass.

## Version floor

This raises the effective `lib_cwmscripture` floor to **1.1.11** (`resolveBookCode`), and #85 needs **1.1.6** (`ConsumerRegistry`). Both predate the 1.1.12 the package currently ships, so nothing in the package needs to move. No `LibraryVersion::VERSION` check was added — it is hardcoded and has drifted from the manifest before (lib #15).

## Not in scope

The `AbstractBibleProvider::bookNames()` delegate #118 proposes for `lib_cwmscripture`. It is a separate repo, no consumer needs it now, and `BookCodes::names()` already covers the case. Worth a decision on the library side, not a blocker here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
