### PR TITLE
style(js): bring the JS sources in line with the shared CWM ESLint base

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,15 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.{js,json,scss,css,yml,vue}]
+# JS is 4-space to match the shared CWM ESLint base config
+# (libraries/vendor/cwm/build-tools/templates/eslint.config.base.mjs), which
+# enforces indent: ['error', 4]. This said 2 while the linter said 4, so
+# `npm run lint:js` reported 361 indent errors against files that were correct
+# by this file's own rule.
+[*.{js,mjs,es6.js}]
+indent_style = space
+indent_size = 4
+
+[*.{json,scss,css,yml,vue}]
 indent_style = space
 indent_size = 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ When in doubt, ask before deleting.
 
 - **PSR-12** base with custom rules via `.php-cs-fixer.dist.php`
 - **EditorConfig** for consistent formatting (`.editorconfig`)
-- PHP: 4-space indent; JS/JSON/CSS/YAML: 2-space indent; others: tabs
+- PHP and JS: 4-space indent; JSON/CSS/YAML: 2-space indent; others: tabs
 - Unix line endings (LF), UTF-8, trim trailing whitespace
 - JS sources live in `build/media_source/js/*.es6.js`; never edit the generated bundles under `media/com_livingword/js/`.
 

--- a/build/media_source/js/livingword-audio.es6.js
+++ b/build/media_source/js/livingword-audio.es6.js
@@ -4,226 +4,231 @@
  * Fetches audio URLs from the server-side controller (keeping API keys private)
  * and provides an HTML5 audio player with optional verse-level sync.
  *
+ * Declaration order is bottom-up — helpers, then setupPlayer, then init —
+ * because these are const arrows rather than hoisted function declarations, so a
+ * use above its definition is only safe by accident of when the callback fires.
+ *
  * @package  Livingword
  * @since    5.2.0
  */
 ((document) => {
-  'use strict';
+    'use strict';
 
-  /**
-   * Initialize all audio player containers on the page.
-   */
-  const init = () => {
-    const players = document.querySelectorAll('[data-livingword-audio]');
+    /**
+     * Fetch audio data from the server controller.
+     *
+     * @param {string} baseUrl  The controller AJAX URL
+     * @param {string} reading  Scripture reference
+     * @param {string} version  Bible translation code
+     *
+     * @returns {Promise<object>}
+     */
+    const fetchAudio = async (baseUrl, reading, version) => {
+        const url = new URL(baseUrl, window.location.origin);
 
-    players.forEach((container) => {
-      const reading = container.dataset.reading || '';
-      const version = container.dataset.version || 'kjv';
-      const baseUrl = container.dataset.audioUrl || '';
+        url.searchParams.set('reading', reading);
+        url.searchParams.set('version', version);
+        url.searchParams.set(Joomla.getOptions('csrf.token', ''), '1');
 
-      if (!reading || !baseUrl) {
-        return;
-      }
-
-      setupPlayer(container, reading, version, baseUrl);
-    });
-  };
-
-  /**
-   * Set up an individual audio player.
-   *
-   * @param {HTMLElement} container  The player container element
-   * @param {string}      reading    Scripture reference
-   * @param {string}      version    Bible translation code
-   * @param {string}      baseUrl    AJAX endpoint URL
-   */
-  const setupPlayer = (container, reading, version, baseUrl) => {
-    const playBtn = container.querySelector('.livingword-audio-play');
-    const audioEl = container.querySelector('audio');
-    const statusEl = container.querySelector('.livingword-audio-status');
-
-    if (!playBtn || !audioEl) {
-      return;
-    }
-
-    let loaded = false;
-    let audioData = null;
-
-    playBtn.addEventListener('click', async () => {
-      if (!loaded) {
-        playBtn.disabled = true;
-
-        if (statusEl) {
-          statusEl.textContent = Joomla.Text._('COM_LIVINGWORD_AUDIO_LOADING') || 'Loading audio...';
-          statusEl.classList.remove('d-none');
-        }
-
-        try {
-          audioData = await fetchAudio(baseUrl, reading, version);
-        } catch (e) {
-          if (statusEl) {
-            statusEl.textContent = Joomla.Text._('COM_LIVINGWORD_AUDIO_ERROR') || 'Audio unavailable';
-            statusEl.classList.add('text-danger');
-          }
-
-          playBtn.disabled = false;
-
-          return;
-        }
-
-        if (!audioData || !audioData.data || !audioData.data.audioUrl) {
-          if (statusEl) {
-            statusEl.textContent = Joomla.Text._('COM_LIVINGWORD_AUDIO_UNAVAILABLE') || 'No audio found';
-          }
-
-          playBtn.disabled = false;
-
-          return;
-        }
-
-        // Build playlist from audioFiles array (multi-chapter support)
-        const playlist = (audioData.data.audioFiles || [audioData.data]).map(f => f.audioUrl);
-        let currentTrack = 0;
-
-        audioEl.src = playlist[0];
-        loaded = true;
-        playBtn.disabled = false;
-
-        if (statusEl) {
-          statusEl.classList.add('d-none');
-        }
-
-        // Show track count for multi-chapter readings
-        if (playlist.length > 1 && statusEl) {
-          statusEl.textContent = '1 / ' + playlist.length;
-          statusEl.classList.remove('d-none');
-        }
-
-        // Set up verse timing sync if available
-        if (audioData.data.verseTiming && audioData.data.verseTiming.length > 0) {
-          setupVerseSync(container, audioEl, audioData.data.verseTiming);
-        }
-
-        // Auto-advance to next chapter when current ends
-        audioEl.addEventListener('ended', () => {
-          currentTrack++;
-
-          if (currentTrack < playlist.length) {
-            audioEl.src = playlist[currentTrack];
-            audioEl.play();
-
-            if (statusEl && playlist.length > 1) {
-              statusEl.textContent = (currentTrack + 1) + ' / ' + playlist.length;
-            }
-          } else {
-            // All chapters done — reset
-            currentTrack = 0;
-            audioEl.src = playlist[0];
-            setPlayIcon();
-
-            if (statusEl && playlist.length > 1) {
-              statusEl.textContent = '';
-              statusEl.classList.add('d-none');
-            }
-          }
+        const response = await fetch(url.toString(), {
+            method: 'GET',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
         });
-      }
 
-      if (audioEl.paused) {
-        audioEl.play();
-        setPauseIcon();
-      } else {
-        audioEl.pause();
-        setPlayIcon();
-      }
-    });
-
-    const setPlayIcon = () => {
-      playBtn.querySelector('.icon-pause, .fa-pause')?.classList.replace('icon-pause', 'icon-play');
-      playBtn.querySelector('.fa-pause')?.classList.replace('fa-pause', 'fa-play');
-      playBtn.setAttribute('aria-label', Joomla.Text._('COM_LIVINGWORD_AUDIO_PLAY') || 'Play');
-    };
-
-    const setPauseIcon = () => {
-      playBtn.querySelector('.icon-play, .fa-play')?.classList.replace('icon-play', 'icon-pause');
-      playBtn.querySelector('.fa-play')?.classList.replace('fa-play', 'fa-pause');
-      playBtn.setAttribute('aria-label', Joomla.Text._('COM_LIVINGWORD_AUDIO_PAUSE') || 'Pause');
-    };
-  };
-
-  /**
-   * Fetch audio data from the server controller.
-   *
-   * @param {string} baseUrl  The controller AJAX URL
-   * @param {string} reading  Scripture reference
-   * @param {string} version  Bible translation code
-   *
-   * @returns {Promise<object>}
-   */
-  const fetchAudio = async (baseUrl, reading, version) => {
-    const url = new URL(baseUrl, window.location.origin);
-
-    url.searchParams.set('reading', reading);
-    url.searchParams.set('version', version);
-    url.searchParams.set(Joomla.getOptions('csrf.token', ''), '1');
-
-    const response = await fetch(url.toString(), {
-      method: 'GET',
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-    });
-
-    if (!response.ok) {
-      throw new Error('HTTP ' + response.status);
-    }
-
-    return response.json();
-  };
-
-  /**
-   * Set up verse-level text highlighting synchronized to audio playback.
-   *
-   * Looks for elements with data-verse="N" inside the container and
-   * highlights the active verse based on audio timestamps.
-   *
-   * @param {HTMLElement}   container    The player container
-   * @param {HTMLAudioElement} audioEl   The audio element
-   * @param {Array}         verseTiming  Array of {verse, timestamp_start, timestamp_end}
-   */
-  const setupVerseSync = (container, audioEl, verseTiming) => {
-    const scriptureContainer = container.closest('.livingword-today-reading')
-      ?.querySelector('.livingword-scripture-text');
-
-    if (!scriptureContainer) {
-      return;
-    }
-
-    audioEl.addEventListener('timeupdate', () => {
-      const currentTime = audioEl.currentTime;
-
-      // Remove all active highlights
-      scriptureContainer.querySelectorAll('.verse-active').forEach((el) => {
-        el.classList.remove('verse-active');
-      });
-
-      // Find and highlight the current verse
-      for (const timing of verseTiming) {
-        if (currentTime >= timing.timestamp_start && currentTime < timing.timestamp_end) {
-          const verseEl = scriptureContainer.querySelector('[data-verse="' + timing.verse + '"]');
-
-          if (verseEl) {
-            verseEl.classList.add('verse-active');
-          }
-
-          break;
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status);
         }
-      }
-    });
-  };
 
-  // Initialize when DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
+        return response.json();
+    };
+
+    /**
+     * Set up verse-level text highlighting synchronized to audio playback.
+     *
+     * Looks for elements with data-verse="N" inside the container and
+     * highlights the active verse based on audio timestamps.
+     *
+     * @param {HTMLElement}   container    The player container
+     * @param {HTMLAudioElement} audioEl   The audio element
+     * @param {Array}         verseTiming  Array of {verse, timestamp_start, timestamp_end}
+     */
+    const setupVerseSync = (container, audioEl, verseTiming) => {
+        const scriptureContainer = container.closest('.livingword-today-reading')
+            ?.querySelector('.livingword-scripture-text');
+
+        if (!scriptureContainer) {
+            return;
+        }
+
+        audioEl.addEventListener('timeupdate', () => {
+            const currentTime = audioEl.currentTime;
+
+            // Remove all active highlights
+            scriptureContainer.querySelectorAll('.verse-active').forEach((el) => {
+                el.classList.remove('verse-active');
+            });
+
+            // Find and highlight the current verse
+            for (const timing of verseTiming) {
+                if (currentTime >= timing.timestamp_start && currentTime < timing.timestamp_end) {
+                    const verseEl = scriptureContainer.querySelector('[data-verse="' + timing.verse + '"]');
+
+                    if (verseEl) {
+                        verseEl.classList.add('verse-active');
+                    }
+
+                    break;
+                }
+            }
+        });
+    };
+
+    /**
+     * Set up an individual audio player.
+     *
+     * @param {HTMLElement} container  The player container element
+     * @param {string}      reading    Scripture reference
+     * @param {string}      version    Bible translation code
+     * @param {string}      baseUrl    AJAX endpoint URL
+     */
+    const setupPlayer = (container, reading, version, baseUrl) => {
+        const playBtn = container.querySelector('.livingword-audio-play');
+        const audioEl = container.querySelector('audio');
+        const statusEl = container.querySelector('.livingword-audio-status');
+
+        if (!playBtn || !audioEl) {
+            return;
+        }
+
+        let loaded = false;
+        let audioData = null;
+
+        const setPlayIcon = () => {
+            playBtn.querySelector('.icon-pause, .fa-pause')?.classList.replace('icon-pause', 'icon-play');
+            playBtn.querySelector('.fa-pause')?.classList.replace('fa-pause', 'fa-play');
+            playBtn.setAttribute('aria-label', Joomla.Text._('COM_LIVINGWORD_AUDIO_PLAY') || 'Play');
+        };
+
+        const setPauseIcon = () => {
+            playBtn.querySelector('.icon-play, .fa-play')?.classList.replace('icon-play', 'icon-pause');
+            playBtn.querySelector('.fa-play')?.classList.replace('fa-play', 'fa-pause');
+            playBtn.setAttribute('aria-label', Joomla.Text._('COM_LIVINGWORD_AUDIO_PAUSE') || 'Pause');
+        };
+
+        playBtn.addEventListener('click', async () => {
+            if (!loaded) {
+                playBtn.disabled = true;
+
+                if (statusEl) {
+                    statusEl.textContent = Joomla.Text._('COM_LIVINGWORD_AUDIO_LOADING') || 'Loading audio...';
+                    statusEl.classList.remove('d-none');
+                }
+
+                try {
+                    audioData = await fetchAudio(baseUrl, reading, version);
+                } catch {
+                    if (statusEl) {
+                        statusEl.textContent = Joomla.Text._('COM_LIVINGWORD_AUDIO_ERROR') || 'Audio unavailable';
+                        statusEl.classList.add('text-danger');
+                    }
+
+                    playBtn.disabled = false;
+
+                    return;
+                }
+
+                if (!audioData || !audioData.data || !audioData.data.audioUrl) {
+                    if (statusEl) {
+                        statusEl.textContent = Joomla.Text._('COM_LIVINGWORD_AUDIO_UNAVAILABLE') || 'No audio found';
+                    }
+
+                    playBtn.disabled = false;
+
+                    return;
+                }
+
+                // Build playlist from audioFiles array (multi-chapter support)
+                const playlist = (audioData.data.audioFiles || [audioData.data]).map(f => f.audioUrl);
+                const [firstTrack] = playlist;
+                let currentTrack = 0;
+
+                audioEl.src = firstTrack;
+                loaded = true;
+                playBtn.disabled = false;
+
+                if (statusEl) {
+                    statusEl.classList.add('d-none');
+                }
+
+                // Show track count for multi-chapter readings
+                if (playlist.length > 1 && statusEl) {
+                    statusEl.textContent = '1 / ' + playlist.length;
+                    statusEl.classList.remove('d-none');
+                }
+
+                // Set up verse timing sync if available
+                if (audioData.data.verseTiming && audioData.data.verseTiming.length > 0) {
+                    setupVerseSync(container, audioEl, audioData.data.verseTiming);
+                }
+
+                // Auto-advance to next chapter when current ends
+                audioEl.addEventListener('ended', () => {
+                    currentTrack += 1;
+
+                    if (currentTrack < playlist.length) {
+                        audioEl.src = playlist[currentTrack];
+                        audioEl.play();
+
+                        if (statusEl && playlist.length > 1) {
+                            statusEl.textContent = (currentTrack + 1) + ' / ' + playlist.length;
+                        }
+                    } else {
+                        // All chapters done — reset
+                        currentTrack = 0;
+                        audioEl.src = firstTrack;
+                        setPlayIcon();
+
+                        if (statusEl && playlist.length > 1) {
+                            statusEl.textContent = '';
+                            statusEl.classList.add('d-none');
+                        }
+                    }
+                });
+            }
+
+            if (audioEl.paused) {
+                audioEl.play();
+                setPauseIcon();
+            } else {
+                audioEl.pause();
+                setPlayIcon();
+            }
+        });
+    };
+
+    /**
+     * Initialize all audio player containers on the page.
+     */
+    const init = () => {
+        const players = document.querySelectorAll('[data-livingword-audio]');
+
+        players.forEach((container) => {
+            const reading = container.dataset.reading || '';
+            const version = container.dataset.version || 'kjv';
+            const baseUrl = container.dataset.audioUrl || '';
+
+            if (!reading || !baseUrl) {
+                return;
+            }
+
+            setupPlayer(container, reading, version, baseUrl);
+        });
+    };
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
 })(document);

--- a/build/media_source/js/livingword-notes.es6.js
+++ b/build/media_source/js/livingword-notes.es6.js
@@ -6,58 +6,58 @@
  * Auto-saving reading notes/journal with debounce.
  */
 document.addEventListener('DOMContentLoaded', function () {
-  'use strict';
+    'use strict';
 
-  var container = document.querySelector('[data-livingword-notes]');
-  if (!container) return;
+    const container = document.querySelector('[data-livingword-notes]');
+    if (!container) return;
 
-  var textarea = container.querySelector('.livingword-notes-textarea');
-  var status = container.querySelector('.livingword-notes-status');
-  var saveUrl = container.dataset.notesUrl;
-  var planId = container.dataset.planId;
-  var day = container.dataset.day;
-  var csrfToken = Joomla.getOptions('csrf.token');
-  var debounceTimer = null;
-  var saving = false;
+    const textarea = container.querySelector('.livingword-notes-textarea');
+    const status = container.querySelector('.livingword-notes-status');
+    const saveUrl = container.dataset.notesUrl;
+    const planId = container.dataset.planId;
+    const day = container.dataset.day;
+    const csrfToken = Joomla.getOptions('csrf.token');
+    let debounceTimer = null;
+    let saving = false;
 
-  function setStatus(text, cssClass) {
-    if (!status) return;
-    status.textContent = text;
-    status.className = 'livingword-notes-status small ' + (cssClass || 'text-muted');
-  }
+    function setStatus(text, cssClass) {
+        if (!status) return;
+        status.textContent = text;
+        status.className = 'livingword-notes-status small ' + (cssClass || 'text-muted');
+    }
 
-  function saveNote() {
-    if (saving) return;
-    saving = true;
-    setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_SAVING') || 'Saving...', 'text-muted');
+    function saveNote() {
+        if (saving) return;
+        saving = true;
+        setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_SAVING') || 'Saving...', 'text-muted');
 
-    var url = saveUrl
+        const url = saveUrl
       + '&plan_id=' + encodeURIComponent(planId)
       + '&day=' + encodeURIComponent(day)
       + '&note_text=' + encodeURIComponent(textarea.value)
       + '&' + csrfToken + '=1';
 
-    fetch(url, { method: 'GET', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-      .then(function (response) { return response.json(); })
-      .then(function (json) {
-        saving = false;
-        if (json.success) {
-          setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_SAVED') || 'Saved', 'text-success');
-        } else {
-          setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_ERROR') || 'Error', 'text-danger');
-        }
-      })
-      .catch(function () {
-        saving = false;
-        setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_ERROR') || 'Error', 'text-danger');
-      });
-  }
+        fetch(url, { method: 'GET', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(function (response) { return response.json(); })
+            .then(function (json) {
+                saving = false;
+                if (json.success) {
+                    setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_SAVED') || 'Saved', 'text-success');
+                } else {
+                    setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_ERROR') || 'Error', 'text-danger');
+                }
+            })
+            .catch(function () {
+                saving = false;
+                setStatus(Joomla.Text._('COM_LIVINGWORD_NOTES_ERROR') || 'Error', 'text-danger');
+            });
+    }
 
-  if (textarea) {
-    textarea.addEventListener('input', function () {
-      setStatus('', '');
-      clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(saveNote, 800);
-    });
-  }
+    if (textarea) {
+        textarea.addEventListener('input', function () {
+            setStatus('', '');
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(saveNote, 800);
+        });
+    }
 });

--- a/build/media_source/js/livingword-progress.es6.js
+++ b/build/media_source/js/livingword-progress.es6.js
@@ -5,219 +5,224 @@
  * and passage-level completion. Requires a CSRF token
  * passed via Joomla's script options (csrf.token).
  *
+ * Declaration order is bottom-up — helpers, then the setup functions that use
+ * them, then init — because these are const arrows rather than hoisted function
+ * declarations, so a use above its definition is only safe by accident of when
+ * the callback fires.
+ *
  * @since 5.3.0
  */
 ((document) => {
-  'use strict';
+    'use strict';
 
-  const init = () => {
-    // Day-level toggle buttons (mark all read/unread)
-    document.querySelectorAll('[data-livingword-progress]').forEach(setupDayToggle);
-    // Passage-level toggle buttons
-    document.querySelectorAll('[data-livingword-passage-toggle]').forEach(setupPassageToggle);
-  };
+    const getTokenName = () => Joomla.getOptions('csrf.token') || '';
 
-  const getTokenName = () => Joomla.getOptions('csrf.token') || '';
-
-  const setupDayToggle = (container) => {
-    const btn = container.querySelector('.livingword-mark-read-btn');
-    if (!btn) return;
-
-    let busy = false;
-
-    btn.addEventListener('click', async (e) => {
-      e.preventDefault();
-      if (busy) return;
-      busy = true;
-
-      const planId = container.dataset.planId;
-      const day = container.dataset.day;
-      const passageCount = container.dataset.passageCount || '1';
-
-      const url = container.dataset.progressUrl
-        + '&plan_id=' + encodeURIComponent(planId)
-        + '&day=' + encodeURIComponent(day)
-        + '&passage_count=' + encodeURIComponent(passageCount)
-        + '&' + encodeURIComponent(getTokenName()) + '=1';
-
-      btn.disabled = true;
-
-      try {
-        const response = await fetch(url, { method: 'GET', credentials: 'same-origin' });
-        if (!response.ok) throw new Error('HTTP ' + response.status);
-
-        const json = await response.json();
-
-        if (json.success && json.data) {
-          const completed = json.data.completed;
-          container.dataset.completed = completed ? '1' : '0';
-
-          updateDayButton(btn, completed);
-          updateDayIndicators(day, completed);
-
-          // Update all passage buttons on the page to match
-          updateAllPassageButtons(completed);
-
-          // Update passage counter text
-          updatePassageCounter(completed ? parseInt(passageCount) : 0, parseInt(passageCount));
+    const updateDayButton = (btn, completed) => {
+        const icon = btn.querySelector('[class^="icon-"]');
+        if (completed) {
+            btn.classList.add('btn-success');
+            btn.classList.remove('btn-outline-secondary');
+            if (icon) icon.className = 'icon-checkmark';
+            btn.setAttribute('aria-label', btn.dataset.labelRead || 'Mark as Unread');
         } else {
-          console.error('LivingWord progress error:', json.message || 'Unknown error');
+            btn.classList.remove('btn-success');
+            btn.classList.add('btn-outline-secondary');
+            if (icon) icon.className = 'icon-checkbox-unchecked';
+            btn.setAttribute('aria-label', btn.dataset.labelUnread || 'Mark as Read');
         }
-      } catch (err) {
-        console.error('LivingWord progress fetch error:', err);
-      } finally {
-        btn.disabled = false;
-        busy = false;
-      }
-    });
-  };
 
-  const setupPassageToggle = (btn) => {
-    let busy = false;
+        // Update button text node (last text content after icon)
+        const textNodes = Array.from(btn.childNodes).filter(n => n.nodeType === Node.TEXT_NODE);
+        if (textNodes.length > 0) {
+            const label = completed
+                ? (btn.dataset.labelRead || 'All Completed')
+                : (btn.dataset.labelUnread || 'Mark All as Read');
+            textNodes[textNodes.length - 1].textContent = '\n                                ' + label + '\n                            ';
+        }
+    };
 
-    btn.addEventListener('click', async (e) => {
-      e.preventDefault();
-      if (busy) return;
-      busy = true;
-
-      const planId = btn.dataset.planId;
-      const day = btn.dataset.day;
-      const passageIndex = btn.dataset.passageIndex;
-      const passageCount = btn.dataset.passageCount || '1';
-
-      const url = btn.dataset.progressUrl
-        + '&plan_id=' + encodeURIComponent(planId)
-        + '&day=' + encodeURIComponent(day)
-        + '&passage_index=' + encodeURIComponent(passageIndex)
-        + '&passage_count=' + encodeURIComponent(passageCount)
-        + '&' + encodeURIComponent(getTokenName()) + '=1';
-
-      btn.disabled = true;
-
-      try {
-        const response = await fetch(url, { method: 'GET', credentials: 'same-origin' });
-        if (!response.ok) throw new Error('HTTP ' + response.status);
-
-        const json = await response.json();
-
-        if (json.success && json.data) {
-          const passageCompleted = json.data.passage_completed;
-          const dayCompleted = json.data.completed;
-
-          // Update this passage button
-          btn.dataset.completed = passageCompleted ? '1' : '0';
-          updatePassageButton(btn, passageCompleted);
-
-          // Update the passage text styling
-          const passageItem = btn.closest('[data-livingword-passage]');
-          if (passageItem) {
-            const lead = passageItem.querySelector('.livingword-scripture-text, .lead, p');
-            if (lead) {
-              lead.classList.toggle('text-decoration-line-through', passageCompleted);
-              lead.classList.toggle('text-muted', passageCompleted);
-            }
-          }
-
-          // Update the day-level "Mark All" button if present
-          const dayContainer = document.querySelector('[data-livingword-progress]');
-          if (dayContainer) {
-            dayContainer.dataset.completed = dayCompleted ? '1' : '0';
-            const dayBtn = dayContainer.querySelector('.livingword-mark-read-btn');
-            if (dayBtn) {
-              updateDayButton(dayBtn, dayCompleted);
-            }
-          }
-
-          // Update passage counter
-          const completedCount = document.querySelectorAll('[data-livingword-passage-toggle][data-completed="1"]').length;
-          const totalCount = parseInt(passageCount);
-          updatePassageCounter(completedCount, totalCount);
-
-          updateDayIndicators(day, dayCompleted);
+    const updatePassageButton = (btn, completed) => {
+        const icon = btn.querySelector('[class^="icon-"]');
+        if (completed) {
+            btn.classList.add('btn-success');
+            btn.classList.remove('btn-outline-secondary');
+            if (icon) icon.className = 'icon-checkmark';
         } else {
-          console.error('LivingWord passage error:', json.message || 'Unknown error');
+            btn.classList.remove('btn-success');
+            btn.classList.add('btn-outline-secondary');
+            if (icon) icon.className = 'icon-checkbox-unchecked';
         }
-      } catch (err) {
-        console.error('LivingWord passage fetch error:', err);
-      } finally {
-        btn.disabled = false;
-        busy = false;
-      }
-    });
-  };
+    };
 
-  const updateDayButton = (btn, completed) => {
-    const icon = btn.querySelector('[class^="icon-"]');
-    if (completed) {
-      btn.classList.add('btn-success');
-      btn.classList.remove('btn-outline-secondary');
-      if (icon) icon.className = 'icon-checkmark';
-      btn.setAttribute('aria-label', btn.dataset.labelRead || 'Mark as Unread');
-    } else {
-      btn.classList.remove('btn-success');
-      btn.classList.add('btn-outline-secondary');
-      if (icon) icon.className = 'icon-checkbox-unchecked';
-      btn.setAttribute('aria-label', btn.dataset.labelUnread || 'Mark as Read');
-    }
+    const updateAllPassageButtons = (completed) => {
+        document.querySelectorAll('[data-livingword-passage-toggle]').forEach(btn => {
+            btn.dataset.completed = completed ? '1' : '0';
+            updatePassageButton(btn, completed);
 
-    // Update button text node (last text content after icon)
-    const textNodes = Array.from(btn.childNodes).filter(n => n.nodeType === Node.TEXT_NODE);
-    if (textNodes.length > 0) {
-      const label = completed
-        ? (btn.dataset.labelRead || 'All Completed')
-        : (btn.dataset.labelUnread || 'Mark All as Read');
-      textNodes[textNodes.length - 1].textContent = '\n                                ' + label + '\n                            ';
-    }
-  };
+            const passageItem = btn.closest('[data-livingword-passage]');
+            if (passageItem) {
+                const lead = passageItem.querySelector('.livingword-scripture-text, .lead, p');
+                if (lead) {
+                    lead.classList.toggle('text-decoration-line-through', completed);
+                    lead.classList.toggle('text-muted', completed);
+                }
+            }
+        });
+    };
 
-  const updatePassageButton = (btn, completed) => {
-    const icon = btn.querySelector('[class^="icon-"]');
-    if (completed) {
-      btn.classList.add('btn-success');
-      btn.classList.remove('btn-outline-secondary');
-      if (icon) icon.className = 'icon-checkmark';
-    } else {
-      btn.classList.remove('btn-success');
-      btn.classList.add('btn-outline-secondary');
-      if (icon) icon.className = 'icon-checkbox-unchecked';
-    }
-  };
+    const updatePassageCounter = (completedCount, totalCount) => {
+        const dayContainer = document.querySelector('[data-livingword-progress]');
+        if (!dayContainer) return;
 
-  const updateAllPassageButtons = (completed) => {
-    document.querySelectorAll('[data-livingword-passage-toggle]').forEach(btn => {
-      btn.dataset.completed = completed ? '1' : '0';
-      updatePassageButton(btn, completed);
-
-      const passageItem = btn.closest('[data-livingword-passage]');
-      if (passageItem) {
-        const lead = passageItem.querySelector('.livingword-scripture-text, .lead, p');
-        if (lead) {
-          lead.classList.toggle('text-decoration-line-through', completed);
-          lead.classList.toggle('text-muted', completed);
+        const counter = dayContainer.querySelector('.text-muted');
+        if (counter && totalCount > 1) {
+            counter.textContent = completedCount + ' of ' + totalCount + ' passages completed';
         }
-      }
-    });
-  };
+    };
 
-  const updatePassageCounter = (completedCount, totalCount) => {
-    const dayContainer = document.querySelector('[data-livingword-progress]');
-    if (!dayContainer) return;
+    const updateDayIndicators = (day, completed) => {
+        document.querySelectorAll('[data-progress-day="' + day + '"]').forEach(el => {
+            el.classList.toggle('livingword-completed', completed);
+        });
+    };
 
-    const counter = dayContainer.querySelector('.text-muted');
-    if (counter && totalCount > 1) {
-      counter.textContent = completedCount + ' of ' + totalCount + ' passages completed';
+    const setupDayToggle = (container) => {
+        const btn = container.querySelector('.livingword-mark-read-btn');
+        if (!btn) return;
+
+        let busy = false;
+
+        btn.addEventListener('click', async (e) => {
+            e.preventDefault();
+            if (busy) return;
+            busy = true;
+
+            const planId = container.dataset.planId;
+            const day = container.dataset.day;
+            const passageCount = container.dataset.passageCount || '1';
+
+            const url = container.dataset.progressUrl
+                + '&plan_id=' + encodeURIComponent(planId)
+                + '&day=' + encodeURIComponent(day)
+                + '&passage_count=' + encodeURIComponent(passageCount)
+                + '&' + encodeURIComponent(getTokenName()) + '=1';
+
+            btn.disabled = true;
+
+            try {
+                const response = await fetch(url, { method: 'GET', credentials: 'same-origin' });
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+
+                const json = await response.json();
+
+                if (json.success && json.data) {
+                    const completed = json.data.completed;
+                    container.dataset.completed = completed ? '1' : '0';
+
+                    updateDayButton(btn, completed);
+                    updateDayIndicators(day, completed);
+
+                    // Update all passage buttons on the page to match
+                    updateAllPassageButtons(completed);
+
+                    // Update passage counter text
+                    updatePassageCounter(completed ? parseInt(passageCount, 10) : 0, parseInt(passageCount, 10));
+                } else {
+                    console.error('LivingWord progress error:', json.message || 'Unknown error');
+                }
+            } catch (err) {
+                console.error('LivingWord progress fetch error:', err);
+            } finally {
+                btn.disabled = false;
+                busy = false;
+            }
+        });
+    };
+
+    const setupPassageToggle = (btn) => {
+        let busy = false;
+
+        btn.addEventListener('click', async (e) => {
+            e.preventDefault();
+            if (busy) return;
+            busy = true;
+
+            const planId = btn.dataset.planId;
+            const day = btn.dataset.day;
+            const passageIndex = btn.dataset.passageIndex;
+            const passageCount = btn.dataset.passageCount || '1';
+
+            const url = btn.dataset.progressUrl
+                + '&plan_id=' + encodeURIComponent(planId)
+                + '&day=' + encodeURIComponent(day)
+                + '&passage_index=' + encodeURIComponent(passageIndex)
+                + '&passage_count=' + encodeURIComponent(passageCount)
+                + '&' + encodeURIComponent(getTokenName()) + '=1';
+
+            btn.disabled = true;
+
+            try {
+                const response = await fetch(url, { method: 'GET', credentials: 'same-origin' });
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+
+                const json = await response.json();
+
+                if (json.success && json.data) {
+                    const passageCompleted = json.data.passage_completed;
+                    const dayCompleted = json.data.completed;
+
+                    // Update this passage button
+                    btn.dataset.completed = passageCompleted ? '1' : '0';
+                    updatePassageButton(btn, passageCompleted);
+
+                    // Update the passage text styling
+                    const passageItem = btn.closest('[data-livingword-passage]');
+                    if (passageItem) {
+                        const lead = passageItem.querySelector('.livingword-scripture-text, .lead, p');
+                        if (lead) {
+                            lead.classList.toggle('text-decoration-line-through', passageCompleted);
+                            lead.classList.toggle('text-muted', passageCompleted);
+                        }
+                    }
+
+                    // Update the day-level "Mark All" button if present
+                    const dayContainer = document.querySelector('[data-livingword-progress]');
+                    if (dayContainer) {
+                        dayContainer.dataset.completed = dayCompleted ? '1' : '0';
+                        const dayBtn = dayContainer.querySelector('.livingword-mark-read-btn');
+                        if (dayBtn) {
+                            updateDayButton(dayBtn, dayCompleted);
+                        }
+                    }
+
+                    // Update passage counter
+                    const completedCount = document.querySelectorAll('[data-livingword-passage-toggle][data-completed="1"]').length;
+                    const totalCount = parseInt(passageCount, 10);
+                    updatePassageCounter(completedCount, totalCount);
+
+                    updateDayIndicators(day, dayCompleted);
+                } else {
+                    console.error('LivingWord passage error:', json.message || 'Unknown error');
+                }
+            } catch (err) {
+                console.error('LivingWord passage fetch error:', err);
+            } finally {
+                btn.disabled = false;
+                busy = false;
+            }
+        });
+    };
+
+    const init = () => {
+        // Day-level toggle buttons (mark all read/unread)
+        document.querySelectorAll('[data-livingword-progress]').forEach(setupDayToggle);
+        // Passage-level toggle buttons
+        document.querySelectorAll('[data-livingword-passage-toggle]').forEach(setupPassageToggle);
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
     }
-  };
-
-  const updateDayIndicators = (day, completed) => {
-    document.querySelectorAll('[data-progress-day="' + day + '"]').forEach(el => {
-      el.classList.toggle('livingword-completed', completed);
-    });
-  };
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
 })(document);


### PR DESCRIPTION
Follow-up to #120, which flagged this. `npm run lint:js` reported **394 errors** across all three files in `build/media_source/js/` — and had for as long as the shared base config has been in use. CI never caught it because `run-lint: false`.

## The disagreement

The shared base (`libraries/vendor/cwm/build-tools/templates/eslint.config.base.mjs`) enforces `indent: ['error', 4]`. This repo's JS sources were 2-space. So **361 of the 394 errors were two conventions disagreeing**, not anything wrong with the code.

`.editorconfig` was that disagreement in writing — it declared JS 2-space while the linter demanded 4. Pointed at 4; `json`/`scss`/`css`/`yml`/`vue` stay at 2 where they were. Worth noting the e2e specs under `tests/` were **already 4-space**, so this is the repo agreeing with itself rather than a new rule imposed on it. lib_cwmscripture and Proclaim both lint clean against the same base. CLAUDE.md's style line follows.

## The 23 that weren't indentation

`eslint --fix` handled the indent and the 10 `no-var` in `livingword-notes`. The rest by hand, and they were worth reading:

| rule | n | what it was |
|---|---|---|
| `no-use-before-define` | 16 | **The interesting one.** These are `const` arrows, not hoisted function declarations — so every one of those calls sat above its own definition and worked only because the calls happen inside callbacks that fire after the module body has run. Reordered bottom-up (helpers → setup functions → `init`), with a note in each file header, since the natural *reading* order is the opposite one. |
| `radix` | 3 | `parseInt(passageCount)` on a `data-*` attribute. Harmless for the values in play, but a leading `0` would have been read as octal on an old engine. |
| `prefer-destructuring` | 2 | `audioEl.src = playlist[0]` twice → one `const [firstTrack] = playlist`, used in both places. |
| `no-plusplus` | 1 | `currentTrack++` → `currentTrack += 1`. |
| `no-unused-vars` | 1 | `catch (e)` that never read `e` → optional catch binding. |

## No behaviour change

Every reordering moves whole declarations. Verified by comparing the sorted, whitespace-stripped lines of each file before and after — they differ **only** by the fixes in the table above, nothing else moved or changed.

`npm run build` produces all six bundles; each passes `node --check`. `npm run lint:js` is now clean, so it can start gating if you want to flip `run-lint` on.

## Review note

The diff is large (462/443) and almost entirely whitespace plus block moves. `git diff -w --color-moved` makes it readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)