### PR TITLE
chore(deps): raise declared dependency ranges to the installed versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "5.6.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@axe-core/playwright": "^4.12.1",
+        "@axe-core/playwright": "^4.13.0",
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "^1.62.0",
+        "@playwright/test": "^1.62.1",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "csso": "^5.0.5",
-        "eslint": "^10.8.0",
-        "globals": "^17.8.0",
-        "rollup": "^4.62.3",
-        "rollup-plugin-gzip": "^4.1.1"
+        "eslint": "^10.8.1",
+        "globals": "^17.11.0",
+        "rollup": "^4.62.4",
+        "rollup-plugin-gzip": "^4.2.0"
       },
       "engines": {
         "node": ">=24.0.0",

--- a/package.json
+++ b/package.json
@@ -13,16 +13,16 @@
     "npm": ">=10.1.0"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.12.1",
+    "@axe-core/playwright": "^4.13.0",
     "@eslint/js": "^10.0.1",
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "csso": "^5.0.5",
-    "eslint": "^10.8.0",
-    "globals": "^17.8.0",
-    "rollup": "^4.62.3",
-    "rollup-plugin-gzip": "^4.1.1"
+    "eslint": "^10.8.1",
+    "globals": "^17.11.0",
+    "rollup": "^4.62.4",
+    "rollup-plugin-gzip": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:js && npm run build:css",


### PR DESCRIPTION
Tail end of #120. That PR updated what is **installed**; the carets in `package.json` still named the old floors, which is what an IDE npm panel reports as "Patch Available" / "Minor Update" even though the tree is already at latest.

| package | declared | installed / latest |
|---|---|---|
| `@axe-core/playwright` | `^4.12.1` → `^4.13.0` | 4.13.0 |
| `@playwright/test` | `^1.62.0` → `^1.62.1` | 1.62.1 |
| `eslint` | `^10.8.0` → `^10.8.1` | 10.8.1 |
| `globals` | `^17.8.0` → `^17.11.0` | 17.11.0 |
| `rollup` | `^4.62.3` → `^4.62.4` | 4.62.4 |
| `rollup-plugin-gzip` | `^4.1.1` → `^4.2.0` | 4.2.0 |

Nothing was broken — `^4.12.1` happily resolves 4.13.0 — but the file no longer described the tree, and the stale floors are noise in every tooling view.

`@eslint/js`, `@rollup/plugin-node-resolve`, `@rollup/plugin-terser` and `csso` are already declared at the version installed, and are left alone.

## No dependency moves

`npm install` changes **only** the mirrored range strings in the lock's root `packages[""]` entry — every resolved version, integrity hash and dependency edge is untouched (6 changed lines, all range strings). `npm outdated` and `npm audit` are clean, `npm run lint:js` is clean, and `npm run build` produces all six bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)