### PR TITLE
ci: gate on composer lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,15 @@ jobs:
     uses: Joomla-Bible-Study/cwm-build-tools/.github/workflows/joomla-package-ci.yml@v1
     with:
       php-version: '8.3'
-      # PHP CS Fixer is off, matching what this project ran before the
-      # migration: `composer lint` has never been part of CI here and the
-      # tree has formatting it would reject. Turn it on in its own change,
-      # after `composer lint:fix` — not as a side effect of adopting the
-      # shared pipeline. The syntax check (`lint:syntax`) still runs.
-      run-lint: false
+      # PHP CS Fixer was held off during the migration because the tree had
+      # formatting it would reject. That debt is paid — `composer lint` reports
+      # 0 of 97 files fixable — so it gates now, in its own change, which is
+      # how the migration comment said to turn it on.
+      #
+      # This covers PHP only. The shared workflow has no JS lint step, so
+      # `npm run lint:js` still runs nowhere in CI even though it is clean as
+      # of #121; gating it needs an input on joomla-package-ci.yml.
+      run-lint: true
       run-lint-syntax: true
       build-command: 'composer build'
       package-glob: 'build/dist/pkg_livingword-*.zip'


### PR DESCRIPTION
`run-lint: false` → `true`.

The migration comment in `ci.yml` said to turn PHP CS Fixer on **in its own change**, after the formatting debt was paid, rather than as a side effect of adopting the shared pipeline. That debt is paid — `composer lint` reports **0 of 97 files fixable** on `main` — so this is that change, and the comment is rewritten to say what is true now.

## Scope — this covers PHP only

Worth being explicit, because "flip the lint gate" sounds broader than it is. `run-lint` in `joomla-package-ci.yml` maps to exactly one step:

```yaml
- if: ${{ inputs.run-lint }}
  run: composer lint
```

**The shared workflow has no JS lint step at all.** It sets up Node 24 and runs `npm ci && npm run build` during packaging, but nothing runs `npm run lint:js` — which is how 394 errors sat in `build/media_source/js/` unnoticed until #121. That file is clean now, and still ungated.

Closing that needs a `run-lint-js` input on `cwm-build-tools/.github/workflows/joomla-package-ci.yml`. That changes every CWM repo's pipeline, so it belongs in its own PR over there rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)