### PR TITLE
ci: gate on npm run lint:js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
       # formatting it would reject. That debt is paid — `composer lint` reports
       # 0 of 97 files fixable — so it gates now, in its own change, which is
       # how the migration comment said to turn it on.
-      #
-      # This covers PHP only. The shared workflow has no JS lint step, so
-      # `npm run lint:js` still runs nowhere in CI even though it is clean as
-      # of #121; gating it needs an input on joomla-package-ci.yml.
       run-lint: true
       run-lint-syntax: true
+      # Added in cwm-build-tools v1.16.0, and reachable because the same release
+      # restored the moving v1 tag. Runs as its own parallel `JS Lint` check,
+      # so it costs the PHP job nothing.
+      run-lint-js: true
       build-command: 'composer build'
       package-glob: 'build/dist/pkg_livingword-*.zip'


### PR DESCRIPTION
Turns on the `run-lint-js` input added in [cwm-build-tools v1.16.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.16.0), completing the chain that started with #121.

The shared pipeline had **no JS lint step at all** — which is exactly how 394 errors sat in `build/media_source/js/` until someone ran the script by hand. `lint:js` is clean as of #121, so this gates it.

It runs as its own parallel **JS Lint** check rather than steps on the PHP job, so the PHP job's critical path is unchanged and a JS failure is legible without opening it.

Also drops the note added in #123 explaining that JS lint ran nowhere — no longer true.

## Why this is possible today

The same cwm-build-tools release restored the moving `v1` tag, which had pointed at **v1.13.2 since 30 July**. This repository has been running that pipeline ever since, so v1.14.0 through v1.16.0 all arrive with this change. That tag now re-points itself on every release rather than depending on someone remembering step 6 of a checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)