### PR TITLE
fix(site): add the missing settings controller, and the E2E that found it

### DIFF
--- a/build.dist.properties
+++ b/build.dist.properties
@@ -75,6 +75,21 @@ builder.j5-test.admin_user  = admin
 builder.j5-test.admin_pass  = admin
 builder.j5-test.admin_email = admin@example.com
 
+# ----- Front-end member account (Playwright member-* projects) -------------
+# The member-j6 project drives the site as a subscriber rather than as an
+# admin, so the specs see the permissions a real visitor gets. Global setup
+# seeds this account through the install's own `cli/joomla.php user:add` and
+# subscribes it to a plan, which needs `builder.<id>.path` to be resolvable —
+# either declared per install, or matchable by directory name in
+# `builder.joomla_paths`.
+#
+# All three default, so most developers need none of these. Set them only to
+# use an account you already have.
+#
+# builder.j6dev.member_username = lw-e2e-member
+# builder.j6dev.member_password = lw-e2e-member-pw-9134
+# builder.j6dev.member_email    = lw-e2e-member@example.com
+
 # ----- CWM sibling paths --------------------------------------------------
 # Per-developer absolute paths to CWM siblings declared in
 # cwm-build.config.json under dev.cwmSiblings. Written by `composer setup`.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -84,6 +84,24 @@ module.exports = defineConfig({
                 baseURL: j6Url,
             },
         },
+        // Front-end specs that need a subscriber. Separate from site-j6 rather
+        // than logging that project in, because the guest state is itself worth
+        // scanning: cwmhome short-circuits to the onboarding picker for anyone
+        // without a plan, so a logged-in site-j6 would stop covering the view
+        // most first-time visitors actually see.
+        //
+        // The account is a plain Registered user seeded by global setup, never
+        // the admin — running these as a Super User would hide every permission
+        // the site applies.
+        {
+            name: 'member-j6',
+            testMatch: '**/member/**/*.spec.js',
+            use: {
+                ...devices['Desktop Chrome'],
+                baseURL: j6Url,
+                storageState: 'tests/e2e/.auth/member-j6.json',
+            },
+        },
         // API acceptance runs against the role=test install and nowhere else.
         // Its whole point is asserting what a package install produces — a
         // symlinked dev site cannot represent that, and a dev site is exactly

--- a/site/language/en-GB/com_livingword.ini
+++ b/site/language/en-GB/com_livingword.ini
@@ -32,6 +32,9 @@ COM_LIVINGWORD_TOOLS_OPEN="Open"
 COM_LIVINGWORD_NO_TOOLS="No study tools are currently available."
 COM_LIVINGWORD_SETTINGS_READING="Reading Preferences"
 COM_LIVINGWORD_SETTINGS_EMAIL="Email Notifications"
+COM_LIVINGWORD_SETTINGS_SAVED="Your preferences have been saved."
+COM_LIVINGWORD_SETTINGS_SAVE_FAILED="Your preferences could not be saved. Please try again."
+COM_LIVINGWORD_SETTINGS_LOGIN_REQUIRED="Please log in to change your preferences."
 COM_LIVINGWORD_AUDIO_VERSION_DEFAULT="Use Plan Default"
 
 ; Study / Devotional

--- a/site/src/Controller/CwmsettingsController.php
+++ b/site/src/Controller/CwmsettingsController.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @package    Livingword.Site
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Livingword\Site\Controller;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\CMS\Session\Session;
+
+/**
+ * Controller for the front-end "My Preferences" form.
+ *
+ * Handles POST `cwmsettings.save`, which is what
+ * `site/tmpl/cwmsettings/default.php` has posted to since the Joomla 5
+ * migration — with no controller behind it. Every save answered
+ * "Invalid controller class: cwmsettings" with a 404, so no user has ever
+ * been able to change their plan, translation, email preferences, timezone
+ * or accountability partner from the site. `CwmsettingsModel::saveSettings()`
+ * was written at the same time and has been complete and unreachable since.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmsettingsController extends BaseController
+{
+    /**
+     * Persist the preferences form for the logged-in user.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function save(): void
+    {
+        $app = Factory::getApplication();
+
+        Session::checkToken('post') || throw new \RuntimeException(Text::_('JINVALID_TOKEN'), 403);
+
+        $user = $app->getIdentity();
+
+        if ($user === null || (int) $user->id === 0) {
+            $app->enqueueMessage(Text::_('COM_LIVINGWORD_SETTINGS_LOGIN_REQUIRED'), 'warning');
+            $app->redirect('index.php?option=com_livingword&view=cwmhome');
+
+            return;
+        }
+
+        $input = $app->getInput();
+
+        $data = [
+            'plan_id'                   => $input->getInt('plan_id', 0),
+            'bible_version'             => $input->getCmd('bible_version', 'kjv'),
+            'audio_version'             => $input->getCmd('audio_version', ''),
+            'email'                     => $input->getInt('email', 0),
+            'email_hour'                => $input->getInt('email_hour', 6),
+            'timezone'                  => $input->getString('timezone', ''),
+            'start_date'                => $input->getString('start_date', ''),
+            'date_offset'               => $input->getInt('date_offset', 0),
+            'date_offset_day'           => $input->getInt('date_offset_day', 0),
+            'action'                    => $input->getCmd('action', ''),
+            'accountability_partner_id' => $input->getInt('accountability_partner_id', 0),
+            'share_progress'            => $input->getInt('share_progress', 0),
+        ];
+
+        /** @var \CWM\Component\Livingword\Site\Model\CwmsettingsModel $model */
+        $model = $this->getModel('Cwmsettings');
+
+        // plan_view is not on this form — it is chosen on the plan view itself.
+        // saveSettings() writes every column, so without carrying the stored
+        // value forward, saving preferences would silently reset the user's
+        // reading layout back to the default.
+        $current           = $model->getUserSettings();
+        $data['plan_view'] = (int) ($current->plan_view ?? 0);
+
+        if ($model->saveSettings($data)) {
+            $app->enqueueMessage(Text::_('COM_LIVINGWORD_SETTINGS_SAVED'), 'message');
+        } else {
+            $app->enqueueMessage(Text::_('COM_LIVINGWORD_SETTINGS_SAVE_FAILED'), 'error');
+        }
+
+        $app->redirect('index.php?option=com_livingword&view=cwmsettings');
+    }
+}

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -27,8 +27,9 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 const { chromium } = require('@playwright/test');
-const { loadProps, installForRole } = require('./helpers/properties');
+const { loadProps, installById, installForRole } = require('./helpers/properties');
 
 /**
  * Project names passed on the command line, e.g. --project=admin-j6.
@@ -181,6 +182,231 @@ async function loginAdminWithRetry(browser, baseUrl, username, password, storage
     }
 }
 
+/**
+ * Ensure the front-end member account exists, using the install's own CLI.
+ *
+ * Seeded rather than assumed: the member specs are about what a subscriber can
+ * do, so they need an account that is not a Super User, and every developer
+ * would otherwise have to hand-create the same one. `user:add` answers "The
+ * username already exists!" on a repeat run, which is success here — what
+ * matters is that the account exists, not who made it.
+ *
+ * Silent no-op when the install declares no filesystem path. A URL-only site
+ * can still be browsed, and if the account really is missing, the login below
+ * fails with a message that says exactly that.
+ *
+ * @param   {object}  install  Install descriptor from installById()
+ *
+ * @returns {void}
+ */
+function ensureMemberAccount(install) {
+    if (!install.path || !fs.existsSync(path.join(install.path, 'cli/joomla.php'))) {
+        return;
+    }
+
+    let output;
+
+    try {
+        output = execFileSync('php', [
+            path.join(install.path, 'cli/joomla.php'),
+            'user:add',
+            `--username=${install.memberUsername}`,
+            '--name=LivingWord E2E Member',
+            `--password=${install.memberPassword}`,
+            `--email=${install.memberEmail}`,
+            '--usergroup=Registered',
+        ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (error) {
+        output = `${error.stdout || ''}${error.stderr || ''}`;
+    }
+
+    if (/already exists/i.test(output) || /User created/i.test(output)) {
+        return;
+    }
+
+    console.log(`  Warning: could not seed ${install.memberUsername} — ${output.trim().slice(0, 200)}`);
+}
+
+/**
+ * Whether a saved state still holds an authenticated front-end session.
+ *
+ * Asks for the profile view, which com_users renders only to a logged-in user
+ * and otherwise answers with the login form.
+ *
+ * @param   {object}  browser           Playwright browser
+ * @param   {string}  baseUrl           Site root
+ * @param   {string}  storageStatePath  Saved state file
+ *
+ * @returns {Promise<boolean>}
+ */
+async function memberStateStillValid(browser, baseUrl, storageStatePath) {
+    if (!fs.existsSync(storageStatePath)) {
+        return false;
+    }
+
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true, storageState: storageStatePath });
+
+    try {
+        const page = await ctx.newPage();
+
+        await page.goto(`${baseUrl}/index.php?option=com_users&view=profile`, {
+            waitUntil: 'domcontentloaded',
+            timeout: 15000,
+        });
+
+        return !(await page.locator('#username').isVisible().catch(() => false));
+    } catch {
+        return false;
+    } finally {
+        await ctx.close();
+    }
+}
+
+/**
+ * Log the member in on the front end and save the session.
+ *
+ * @param   {object}  browser           Playwright browser
+ * @param   {object}  install           Install descriptor from installById()
+ * @param   {string}  storageStatePath  Where to save the session
+ *
+ * @returns {Promise<void>}
+ */
+async function loginMember(browser, install, storageStatePath) {
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+
+    try {
+        const page = await ctx.newPage();
+
+        await page.goto(`${install.url}/index.php?option=com_users&view=login`, { waitUntil: 'domcontentloaded' });
+        await page.fill('#username', install.memberUsername);
+        await page.fill('#password', install.memberPassword);
+
+        // Enter rather than a button click: the login module and the com_users
+        // login view render different submit controls depending on template,
+        // and both submit the form the field belongs to.
+        await page.locator('#password').press('Enter');
+        await page.waitForLoadState('domcontentloaded');
+
+        await page.goto(`${install.url}/index.php?option=com_users&view=profile`, { waitUntil: 'domcontentloaded' });
+
+        if (await page.locator('#username').isVisible().catch(() => false)) {
+            throw new Error(
+                `Front-end login failed for ${install.memberUsername} at ${install.url}.\n` +
+                'Set builder.<install>.member_username / member_password in build.properties, or let global ' +
+                'setup seed the account by declaring builder.<install>.path.'
+            );
+        }
+
+        await ctx.storageState({ path: storageStatePath });
+        console.log(`  Saved member session → ${path.basename(storageStatePath)}`);
+    } finally {
+        await ctx.close();
+    }
+}
+
+/**
+ * Ensure the member is subscribed to a reading plan.
+ *
+ * Not cosmetic setup — it is what makes most of the site reachable at all.
+ * cwmhome short-circuits to the onboarding picker for anyone without a plan,
+ * and cwmplanview, cwmgroups and cwmsettings render that same picker, so an
+ * unsubscribed session sees the onboarding hero at every one of those URLs and
+ * a spec looking for their real content finds nothing.
+ *
+ * Subscribing through the onboarding form rather than the database keeps the
+ * fixture honest: it is the same POST a first-time visitor makes, so if
+ * cwmsubscribe.start ever breaks, every member spec fails at setup and says so.
+ *
+ * @param   {object}  browser  Playwright browser
+ * @param   {object}  install  Install descriptor from installById()
+ * @param   {string}  statePath  Saved member session
+ *
+ * @returns {Promise<void>}
+ */
+async function ensureMemberSubscription(browser, install, statePath) {
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true, storageState: statePath });
+
+    try {
+        const page = await ctx.newPage();
+
+        await page.goto(`${install.url}/index.php?option=com_livingword&view=cwmhome`, {
+            waitUntil: 'domcontentloaded',
+        });
+
+        const subscribe = page.locator('form[action*="cwmsubscribe"] button[type="submit"]').first();
+
+        if (!(await subscribe.count())) {
+            return;
+        }
+
+        console.log('  Member has no plan — subscribing through the onboarding form.');
+        await subscribe.click();
+        await page.waitForLoadState('domcontentloaded');
+
+        const stillOnboarding = await page.locator('.com-livingword-onboarding').count();
+
+        if (stillOnboarding) {
+            console.log('  Warning: the member is still unsubscribed after posting cwmsubscribe.start.');
+
+            return;
+        }
+
+        // The subscription lives in #__livingword_users, not the session, but
+        // re-saving keeps this state file the single thing a spec needs.
+        await ctx.storageState({ path: statePath });
+    } finally {
+        await ctx.close();
+    }
+}
+
+/**
+ * Authenticate the front-end member for any selected project that wants one.
+ *
+ * Mirrors the admin pass above: a project needs a member session exactly when
+ * it declares that session's storageState, so running only `--project=site-j6`
+ * never logs anybody in.
+ *
+ * @param   {object}    config    Resolved Playwright config
+ * @param   {object}    props     build.properties
+ * @param   {string}    authDir   Directory holding saved sessions
+ * @param   {string[]}  selected  Project names from argv, empty for all
+ *
+ * @returns {Promise<void>}
+ */
+async function authenticateMembers(config, props, authDir, selected) {
+    const stateFile = 'member-j6.json';
+    const projects  = (config.projects || [])
+        .filter((p) => !selected.length || selected.includes(p.name));
+
+    const wanted = projects.some(
+        (p) => p.use && typeof p.use.storageState === 'string' && p.use.storageState.endsWith(stateFile)
+    );
+
+    if (!wanted) {
+        return;
+    }
+
+    const install   = installById(props, 'j6dev');
+    const statePath = path.join(authDir, stateFile);
+
+    ensureMemberAccount(install);
+
+    const browser = await chromium.launch({ channel: 'chromium' });
+
+    try {
+        if (await memberStateStillValid(browser, install.url, statePath)) {
+            console.log(`Reusing valid member session for ${install.id} (${stateFile}).`);
+        } else {
+            console.log(`\nAuthenticating member ${install.memberUsername} against ${install.url}…`);
+            await loginMember(browser, install, statePath);
+        }
+
+        await ensureMemberSubscription(browser, install, statePath);
+    } finally {
+        await browser.close();
+    }
+}
+
 module.exports = async function globalSetup(config) {
     const root = path.join(__dirname, '../..');
     const props = loadProps(root);
@@ -231,8 +457,12 @@ module.exports = async function globalSetup(config) {
         (p) => p.use && typeof p.use.storageState === 'string' && p.use.storageState.endsWith(site.stateFile)
     ));
 
+    // Before the early return below: a run of member specs alone needs no
+    // admin session at all, and must still get its member one.
+    await authenticateMembers(config, props, authDir, selected);
+
     if (!needed.length) {
-        console.log('\nGlobal setup: no selected project needs an admin session; nothing to authenticate.\n');
+        console.log('\nGlobal setup: no selected project needs an admin session.\n');
         return;
     }
 

--- a/tests/e2e/helpers/properties.js
+++ b/tests/e2e/helpers/properties.js
@@ -62,18 +62,57 @@ function installIds(props) {
 /**
  * Connection details for one named install.
  *
+ * `path` is the filesystem root, needed by anything that shells out to the
+ * install's own `cli/joomla.php` — seeding the front-end member account, for
+ * one. It is per-install (`builder.<id>.path`, as CI writes it) and falls back
+ * to positional lookup in the legacy comma-separated `builder.joomla_paths`,
+ * which is how the older dev installs are still declared. Empty when neither
+ * answers, and callers must cope: a URL-only install can still be browsed, it
+ * just cannot be seeded.
+ *
+ * `member*` is the front-end account the member-* projects log in as. Not the
+ * admin: these specs exercise what a subscriber can do, and running them as a
+ * Super User would hide every permission the site actually applies.
+ *
  * @param {object} props
  * @param {string} id
- * @returns {{id: string, role: string, url: string, username: string, password: string}}
+ * @returns {{id: string, role: string, url: string, path: string, username: string, password: string,
+ *            memberUsername: string, memberPassword: string, memberEmail: string}}
  */
 function installById(props, id) {
     return {
         id,
         role: props[`builder.${id}.role`] || '',
         url: props[`builder.${id}.url`] || '',
+        path: props[`builder.${id}.path`] || pathFromJoomlaPaths(props, id),
         username: props[`builder.${id}.username`] || props['builder.joomla_username'] || '',
         password: props[`builder.${id}.password`] || props['builder.joomla_password'] || '',
+        memberUsername: props[`builder.${id}.member_username`] || 'lw-e2e-member',
+        memberPassword: props[`builder.${id}.member_password`] || 'lw-e2e-member-pw-9134',
+        memberEmail: props[`builder.${id}.member_email`] || 'lw-e2e-member@example.com',
     };
+}
+
+/**
+ * Recover an install root from the legacy `builder.joomla_paths` list.
+ *
+ * The list is positional and carries no ids, so match on the directory name:
+ * install id `j6dev` against a path ending `j6-dev` or `j6dev`. Only used when
+ * the install declares no `builder.<id>.path` of its own.
+ *
+ * @param {object} props
+ * @param {string} id
+ * @returns {string}
+ */
+function pathFromJoomlaPaths(props, id) {
+    const paths = (props['builder.joomla_paths'] || props['builder.joomla_path'] || '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+
+    const wanted = id.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+    return paths.find((entry) => path.basename(entry).toLowerCase().replace(/[^a-z0-9]/g, '') === wanted) || '';
 }
 
 /**

--- a/tests/e2e/member/settings.spec.js
+++ b/tests/e2e/member/settings.spec.js
@@ -1,0 +1,150 @@
+/**
+ * Front-end preferences, end to end, as a subscriber.
+ *
+ * This suite exists because of what it found. `site/tmpl/cwmsettings/default.php`
+ * has posted to `task=cwmsettings.save` since the Joomla 3 → 5 migration, and
+ * no CwmsettingsController was ever written, so every save answered
+ * "Invalid controller class: cwmsettings" with a 404. Nobody could change their
+ * plan, translation, email preferences, timezone or accountability partner from
+ * the site, in any release of the Joomla 5 line.
+ *
+ * Nothing caught it because nothing posted the form. The a11y scans visit
+ * cwmsettings as a guest, so they render the login prompt and never reach it.
+ *
+ * The round trip is therefore the point: fill, submit, reload, and read the
+ * values back out of a fresh render. Asserting on the success message alone
+ * would pass against a controller that redirects without writing anything.
+ *
+ * @package  Livingword.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const SETTINGS = 'index.php?option=com_livingword&view=cwmsettings';
+
+/**
+ * The value of an option that is not currently selected, so a save has
+ * something to prove. Returns null when the control offers no alternative.
+ *
+ * @param   {object}  select  Playwright locator for a <select>
+ *
+ * @returns {Promise<string|null>}
+ */
+async function anotherOption(select) {
+    const current = await select.inputValue();
+    const values = await select.locator('option').evaluateAll(
+        (options) => options.map((option) => option.value).filter((value) => value !== '')
+    );
+
+    return values.find((value) => value !== current) ?? null;
+}
+
+/**
+ * Whether cwmsettings actually renders its form.
+ *
+ * It does not, for a member without a plan: cwmsettings, cwmplanview and
+ * cwmgroups all fall back to cwmhome's onboarding picker, so the URL answers
+ * 200 with LivingWord markup that contains no form at all. Global setup
+ * subscribes the member for exactly this reason, and this guard covers the
+ * case where that did not take — skipping with the reason beats failing as
+ * though the preferences code were broken.
+ *
+ * @param   {object}  page  Playwright page
+ *
+ * @returns {Promise<boolean>}
+ */
+async function settingsViewReachable(page) {
+    await page.goto(SETTINGS);
+
+    return page.locator('#settingsForm').count().then((n) => n > 0);
+}
+
+test.describe('Front-end preferences @member', () => {
+    test.beforeEach(async ({ page }) => {
+        test.skip(
+            !(await settingsViewReachable(page)),
+            'cwmsettings does not route to itself on this site — the view renders the default page instead'
+        );
+    });
+
+    test('the preferences form renders for a logged-in member', async ({ page }) => {
+        await page.goto(SETTINGS);
+
+        await expect(page.locator('#settingsForm')).toBeVisible();
+        await expect(page.locator('#bible_version')).toBeVisible();
+    });
+
+    test('saving reaches a controller rather than a 404', async ({ page }) => {
+        await page.goto(SETTINGS);
+
+        const response = await Promise.all([
+            page.waitForResponse((r) => r.request().method() === 'POST'),
+            page.locator('#settingsForm button[type="submit"]:not([name="action"])').click(),
+        ]).then(([r]) => r);
+
+        // The bug this suite was written for: com_livingword answered every
+        // save with 404 "Invalid controller class: cwmsettings".
+        expect(response.status(), 'POST to cwmsettings.save must not 404').not.toBe(404);
+        await expect(page.locator('body')).not.toContainText('Invalid controller class');
+    });
+
+    test('a changed translation survives a reload', async ({ page }) => {
+        await page.goto(SETTINGS);
+
+        const select = page.locator('#bible_version');
+        const target = await anotherOption(select);
+
+        test.skip(target === null, 'only one translation is configured, so nothing can change');
+
+        await select.selectOption(target);
+        await page.locator('#settingsForm button[type="submit"]:not([name="action"])').click();
+        await page.waitForLoadState('domcontentloaded');
+
+        // Read it back from a fresh render, not from the redirected page: the
+        // point is that it reached the database.
+        await page.goto(SETTINGS);
+        await expect(page.locator('#bible_version')).toHaveValue(target);
+    });
+
+    test('the email opt-in toggles and persists', async ({ page }) => {
+        await page.goto(SETTINGS);
+
+        const optIn  = page.locator('#email');
+        const before = await optIn.isChecked();
+
+        await optIn.setChecked(!before);
+        await page.locator('#settingsForm button[type="submit"]:not([name="action"])').click();
+        await page.waitForLoadState('domcontentloaded');
+
+        await page.goto(SETTINGS);
+        await expect(page.locator('#email')).toBeChecked({ checked: !before });
+
+        // Put it back, so a re-run starts where this one did.
+        await page.locator('#email').setChecked(before);
+        await page.locator('#settingsForm button[type="submit"]:not([name="action"])').click();
+        await page.waitForLoadState('domcontentloaded');
+    });
+
+    test('saving preferences does not drop the subscription', async ({ page }) => {
+        // saveSettings() rewrites every column of the user's row, including
+        // ones this form does not post — plan_view among them. A controller
+        // that sent defaults for those would quietly undo the subscription and
+        // drop the member back to the onboarding picker, which is the state
+        // every plan-bearing view falls back to.
+        await page.goto(SETTINGS);
+        await expect(page.locator('#settingsForm input[name="plan_view"], #settingsForm select[name="plan_view"]'))
+            .toHaveCount(0);
+
+        await page.locator('#settingsForm button[type="submit"]:not([name="action"])').click();
+        await page.waitForLoadState('domcontentloaded');
+
+        for (const view of ['cwmhome', 'cwmplanview']) {
+            await page.goto(`index.php?option=com_livingword&view=${view}`);
+            await expect(
+                page.locator('.com-livingword-onboarding'),
+                `${view} fell back to onboarding after saving preferences`
+            ).toHaveCount(0);
+        }
+    });
+});


### PR DESCRIPTION
## The bug

`site/tmpl/cwmsettings/default.php` posts to `task=cwmsettings.save`. **No `CwmsettingsController` was ever written.** Every save answered:

```
404 — Invalid controller class: cwmsettings
```

So no user has been able to change their plan, translation, audio version, email opt-in, email hour, timezone, accountability partner or progress sharing from the front end — in **any release of the Joomla 5 line**, including 5.7.0-beta1, cut an hour before this was found. `git log -S` puts the form action in the original migration commit.

`CwmsettingsModel::saveSettings()` was written at the same time as the template. It is complete, correct, and has been unreachable ever since.

One subtlety in the fix: the controller carries `plan_view` forward from the stored row. `saveSettings()` writes every column, and this form doesn't post `plan_view` — the reading layout is chosen on the plan view — so a naive controller would silently reset it on every save.

## Why nothing caught it

The a11y specs visit `cwmsettings` **as a guest**, so they scan the login prompt and never render the form, let alone post it. The suite proved the page was accessible while the feature behind it was dead — 2 assertions per page, both about rendering.

## The member tier

So this adds the front-end tier `playwright.config.js` has anticipated since it was written ("anything under tests/e2e/site as a visitor"):

- **`properties.js`** exposes each install's filesystem path — declared as `builder.<id>.path` (as CI already writes it) or matched by directory name in the legacy `builder.joomla_paths` — plus member credentials, all defaulted.
- **`global-setup.js`** seeds a plain **Registered** account through the install's own `cli/joomla.php user:add`, logs it in on the front end, and subscribes it to a plan **by posting the onboarding form** — the same POST a first-time visitor makes, so a broken `cwmsubscribe.start` fails every member spec at setup and says so.
- **`member-j6`** project runs `tests/e2e/member/**` with that session. Deliberately separate from `site-j6`, which stays a guest: `cwmhome` short-circuits to the onboarding picker for anyone without a plan, so logging `site-j6` in would stop it covering the view most first-time visitors actually see.

The subscription is not cosmetic. `cwmsettings`, `cwmplanview` and `cwmgroups` all render that same onboarding picker for a member with no plan — HTTP 200, LivingWord markup, no form in it. That's why the specs first looked like they'd hit a routing fault, and it's worth knowing before writing any further member spec.

## What the specs assert

The **round trip**, not the redirect: change a value, submit, reload, read it back from a fresh render. Asserting on a success message would pass against a controller that redirects without writing anything. One spec pins the 404 directly, so this exact regression cannot come back silently.

## Verification

- 5/5 member specs pass
- **36/36 across the whole e2e suite** — admin a11y, site a11y, member, API acceptance
- `composer lint`, `npm run lint:js`, 52 unit tests all clean

## Next

This is the first tranche of the broader coverage work. Still uncovered: admin CRUD, the reading/progress journey, notes autosave, group join/leave, valid-token email landings, and the task plugin's three routines (reachable via `scheduler:run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)