### PR TITLE
fix(scripture): survive a library fault, and cover reading progress end to end

### DIFF
--- a/site/src/Helper/CwmscriptureHelper.php
+++ b/site/src/Helper/CwmscriptureHelper.php
@@ -61,8 +61,16 @@ class CwmscriptureHelper
             return null;
         }
 
-        $params   = \CWM\Library\Scripture\Helper\ScriptureParamsHelper::getParams();
-        $provider = \CWM\Library\Scripture\Bible\BibleProviderFactory::getProviderForTranslation($version, $params);
+        // Acquiring the provider is guarded for the same reason the fetch below
+        // is: this component treats the library as optional and answers with a
+        // BibleGateway link when it cannot help, which a fatal here would deny
+        // it the chance to do.
+        try {
+            $params   = \CWM\Library\Scripture\Helper\ScriptureParamsHelper::getParams();
+            $provider = \CWM\Library\Scripture\Bible\BibleProviderFactory::getProviderForTranslation($version, $params);
+        } catch (\Throwable) {
+            return null;
+        }
 
         $passages  = array_map('trim', explode(';', $reading));
         $allText   = [];
@@ -75,7 +83,15 @@ class CwmscriptureHelper
 
             try {
                 $result = $provider->getPassage($passage, $version);
-            } catch (\Exception) {
+            } catch (\Throwable) {
+                // Throwable, not Exception. A fault inside the library is an
+                // Error as often as an Exception — AbstractBibleProvider's
+                // cache read calls $this->getDatabase(), which no provider
+                // defines, so every cached lookup raises "Call to undefined
+                // method" (lib_cwmscripture). Catching Exception alone let
+                // that escape and take the whole reading page down with a 500,
+                // in a component whose every call site is written to fall back
+                // to a BibleGateway link when the library cannot answer.
                 continue;
             }
 
@@ -280,15 +296,19 @@ class CwmscriptureHelper
             return null;
         }
 
-        $params    = \CWM\Library\Scripture\Helper\ScriptureParamsHelper::getParams();
-        $bbEnabled = (int) $params->get('provider_biblebrain', 0) === 1;
-        $bbKey     = (string) $params->get('biblebrain_api_key', '');
+        try {
+            $params    = \CWM\Library\Scripture\Helper\ScriptureParamsHelper::getParams();
+            $bbEnabled = (int) $params->get('provider_biblebrain', 0) === 1;
+            $bbKey     = (string) $params->get('biblebrain_api_key', '');
 
-        if (!$bbEnabled || empty($bbKey)) {
+            if (!$bbEnabled || empty($bbKey)) {
+                return null;
+            }
+
+            $provider = \CWM\Library\Scripture\Bible\BibleProviderFactory::getProvider('biblebrain', $bbKey);
+        } catch (\Throwable) {
             return null;
         }
-
-        $provider = \CWM\Library\Scripture\Bible\BibleProviderFactory::getProvider('biblebrain', $bbKey);
 
         if (!($provider instanceof \CWM\Library\Scripture\Bible\AudioProviderInterface)) {
             return null;
@@ -316,7 +336,10 @@ class CwmscriptureHelper
             foreach ($chapters as $chapter) {
                 try {
                     $result = $provider->getAudio($parsed['book'], $chapter, $version);
-                } catch (\Exception) {
+                } catch (\Throwable) {
+                    // Throwable for the same reason as the passage fetch above:
+                    // a library-side Error must degrade to "no audio", never to
+                    // a fatal.
                     continue;
                 }
 
@@ -367,10 +390,14 @@ class CwmscriptureHelper
             return false;
         }
 
-        $params = \CWM\Library\Scripture\Helper\ScriptureParamsHelper::getParams();
+        try {
+            $params = \CWM\Library\Scripture\Helper\ScriptureParamsHelper::getParams();
 
-        return (int) $params->get('provider_biblebrain', 0) === 1
-            && !empty($params->get('biblebrain_api_key', ''));
+            return (int) $params->get('provider_biblebrain', 0) === 1
+                && !empty($params->get('biblebrain_api_key', ''));
+        } catch (\Throwable) {
+            return false;
+        }
     }
 
     /**

--- a/tests/e2e/member/progress.spec.js
+++ b/tests/e2e/member/progress.spec.js
@@ -1,0 +1,182 @@
+/**
+ * Reading progress, end to end, as a subscriber.
+ *
+ * The component's central promise: a reader opens today's reading, marks it
+ * read, and that survives. It is also the most JavaScript-dependent thing the
+ * site does — cwmprogress.toggle is an AJAX endpoint, the button state is
+ * rewritten in the browser, and none of it is exercised by a page scan.
+ *
+ * Every assertion here reads state back after a reload rather than trusting
+ * the optimistic DOM update. A handler that flips a class without persisting
+ * looks identical to a working one until the page is loaded again, and that is
+ * exactly the failure worth catching.
+ *
+ * Each test restores the state it found, so the suite is re-runnable against a
+ * long-lived dev site rather than only a freshly reset one.
+ *
+ * @package  Livingword.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const HOME = 'index.php?option=com_livingword&view=cwmhome';
+
+const DAY_CONTAINER = '[data-livingword-progress]';
+const DAY_BUTTON    = '[data-livingword-progress] .livingword-mark-read-btn';
+const PASSAGE       = '[data-livingword-passage-toggle]';
+
+/**
+ * Click a progress control and wait for the server to answer.
+ *
+ * Waiting on the response rather than a DOM change is deliberate: the DOM
+ * changes optimistically, so asserting on it straight after the click would
+ * pass even when the request failed.
+ *
+ * @param   {object}  page     Playwright page
+ * @param   {object}  locator  The control to click
+ *
+ * @returns {Promise<object>}  The parsed JSON body
+ */
+async function toggleAndWait(page, locator) {
+    const [response] = await Promise.all([
+        page.waitForResponse((r) => r.url().includes('cwmprogress.toggle')),
+        locator.click(),
+    ]);
+
+    expect(response.status(), 'the progress endpoint must answer 200').toBe(200);
+
+    return response.json();
+}
+
+/**
+ * Whether the day is currently marked complete, read from the server-rendered
+ * markup rather than from any class the browser may have applied.
+ *
+ * @param   {object}  page  Playwright page
+ *
+ * @returns {Promise<boolean>}
+ */
+async function dayIsComplete(page) {
+    return (await page.locator(DAY_CONTAINER).getAttribute('data-completed')) === '1';
+}
+
+test.describe('Reading progress @member', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(HOME);
+
+        test.skip(
+            !(await page.locator(DAY_CONTAINER).count()),
+            'no reading is scheduled for today on this plan, so there is no progress control to drive'
+        );
+    });
+
+    test("today's reading offers a progress control to a subscriber", async ({ page }) => {
+        await expect(page.locator(DAY_BUTTON)).toBeVisible();
+
+        // The control carries what the endpoint needs. A missing plan or day
+        // here is why toggling would answer "Invalid plan or day".
+        const container = page.locator(DAY_CONTAINER);
+
+        expect(Number(await container.getAttribute('data-plan-id')), 'plan id').toBeGreaterThan(0);
+        expect(Number(await container.getAttribute('data-day')), 'reading day').toBeGreaterThan(0);
+    });
+
+    test('marking the day read survives a reload', async ({ page }) => {
+        const before = await dayIsComplete(page);
+
+        const body = await toggleAndWait(page, page.locator(DAY_BUTTON));
+
+        expect(body.success, 'the endpoint reports success').toBeTruthy();
+        expect(body.data.completed, 'the answer flips the day').toBe(!before);
+
+        await page.goto(HOME);
+        expect(await dayIsComplete(page), 'the new state came back from the database').toBe(!before);
+
+        // Put it back.
+        await toggleAndWait(page, page.locator(DAY_BUTTON));
+        await page.goto(HOME);
+        expect(await dayIsComplete(page), 'restored to the state this test found').toBe(before);
+    });
+
+    test('marking the day read marks every passage of it', async ({ page }) => {
+        const passages = page.locator(PASSAGE);
+        const count    = await passages.count();
+
+        test.skip(count === 0, "today's reading has no per-passage controls");
+
+        const before = await dayIsComplete(page);
+
+        if (before) {
+            await toggleAndWait(page, page.locator(DAY_BUTTON));
+            await page.goto(HOME);
+        }
+
+        await toggleAndWait(page, page.locator(DAY_BUTTON));
+        await page.goto(HOME);
+
+        // Read from the server-rendered attributes: the JS updates these in the
+        // browser too, so only a reload proves the passages were written.
+        const states = await page.locator(PASSAGE).evaluateAll(
+            (nodes) => nodes.map((node) => node.dataset.completed)
+        );
+
+        expect(states.every((state) => state === '1'), 'every passage is complete').toBeTruthy();
+
+        await toggleAndWait(page, page.locator(DAY_BUTTON));
+
+        if (before) {
+            await page.goto(HOME);
+            await toggleAndWait(page, page.locator(DAY_BUTTON));
+        }
+    });
+
+    test('a single passage toggles without completing the day', async ({ page }) => {
+        const passages = page.locator(PASSAGE);
+        const count    = await passages.count();
+
+        test.skip(count < 2, 'needs a reading with more than one passage to tell the two apart');
+
+        // Start from a day that is not complete, so completing one passage
+        // cannot be confused with the day already being done.
+        if (await dayIsComplete(page)) {
+            await toggleAndWait(page, page.locator(DAY_BUTTON));
+            await page.goto(HOME);
+        }
+
+        const body = await toggleAndWait(page, page.locator(PASSAGE).first());
+
+        expect(body.data.passage_completed, 'the passage is complete').toBeTruthy();
+        expect(body.data.completed, 'one passage of several does not complete the day').toBeFalsy();
+
+        await page.goto(HOME);
+
+        const states = await page.locator(PASSAGE).evaluateAll(
+            (nodes) => nodes.map((node) => node.dataset.completed)
+        );
+
+        expect(states[0], 'the toggled passage persisted').toBe('1');
+        expect(states.slice(1).some((state) => state === '0'), 'the others are untouched').toBeTruthy();
+
+        await toggleAndWait(page, page.locator(PASSAGE).first());
+    });
+
+    test('the endpoint refuses a request without a session token', async ({ page }) => {
+        // The button always sends the token, so only a direct request covers
+        // this. CSRF on a state-changing GET is the whole reason the token is
+        // there — a reader's progress should not be editable by any page that
+        // can make their browser issue a request.
+        const body = await page.evaluate(async () => {
+            const url = new URL(window.location.origin);
+
+            url.pathname = '/index.php';
+            url.search = 'option=com_livingword&task=cwmprogress.toggle&format=json&plan_id=1&day=1&passage_count=1';
+
+            const res = await fetch(url.toString(), { credentials: 'same-origin' });
+
+            return { status: res.status, text: await res.text() };
+        });
+
+        expect(body.text, 'an untokened toggle is refused').toContain('Invalid session token');
+    });
+});


### PR DESCRIPTION
Writing the reading-progress specs turned up a **fatal on the reading page**:

```
Call to undefined method CWM\Library\Scripture\Bible\Provider\ApiBibleProvider::getDatabase()
  lib_cwmscripture/src/Bible/AbstractBibleProvider.php:251  readCache()
  lib_cwmscripture/src/Bible/Provider/ApiBibleProvider.php:92
```

`readCache()` and `writeCache()` both call `$this->getDatabase()`, and **nothing in lib_cwmscripture defines it** — no `DatabaseAwareTrait`, no method, since the initial library import. Three providers reach it: ApiBible, GetBible, BibleBrain. Filed as lib_cwmscripture#61; not ours to fix.

## Ours is that it took the page down

This component is written throughout to treat lib_cwmscripture as **optional**, falling back to a BibleGateway link — that is the premise behind every `class_exists()` guard and behind the `ConsumerRegistry` work in #119. But the guards caught `\Exception`, and an undefined method raises an **`Error`**, which is a `Throwable` and not an `Exception`. So the fallback never got the chance to run and the reader got a 500 instead of a link.

- Both fetch sites (`getPassage`, `getAudio`) now catch `\Throwable`.
- The **three provider-acquisition sites that were not guarded at all** are wrapped too — a fault while resolving params or building a provider has exactly the same consequence as one while fetching.

## The specs

What a subscriber actually does, on the component's central promise:

| spec | what it pins |
|---|---|
| control renders | the plan id and day the endpoint needs are present — a missing one is why toggling answers "Invalid plan or day" |
| day read survives a reload | the round trip, read back from the database |
| day read marks every passage | the fan-out the JS performs is actually persisted |
| one passage ≠ whole day | a multi-passage day is not completed by one passage |
| untokened toggle refused | CSRF on a state-changing GET, which only a direct request can cover |

Every assertion reads state back **after a reload** rather than trusting the optimistic DOM update — a handler that flips a class without persisting looks identical to a working one until the page is loaded again. Each test restores what it found, so the suite re-runs against a long-lived dev site.

## Two environmental traps, recorded because they cost an hour

- **A member with no plan** sees the onboarding picker at `cwmhome`, `cwmplanview`, `cwmgroups` *and* `cwmsettings` — HTTP 200, LivingWord markup, none of the real content. Global setup subscribes the member; the specs skip with a reason if that didn't take. I nearly filed this as a routing bug before probing with a real session.
- **`media/com_livingword` was symlinked one level high** on j5-dev and j6-dev — at the repo's `media/` rather than `media/com_livingword/` — so no component CSS or JS loaded and every progress button was inert. `composer symlink:check` reports it as `WRONG`; `composer symlink -- --force` repairs it. **The packaged install was never affected**, which is why the API and install suites stayed green.

## Verification

8 passed, 2 skipped across the member suite. The two skips are correct: today's reading is single-passage, so the per-passage specs have nothing to drive and say so. `composer lint`, `npm run lint:js`, 52 unit tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
