### PR TITLE
ci: stop the release workflow fighting the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Only when nothing published this tag already.
+      #
+      # `composer release` (cwm-release) builds, creates the GitHub release,
+      # uploads the zip and publishes to ARS — all before the tag it pushes
+      # reaches this workflow. So this step lost the race on every release
+      # since v5.6.0-beta1 and failed the run with "a release with the same tag
+      # name already exists", six red runs deep by 5.7.0-beta3.
+      #
+      # The build above is still worth running: it proves the package builds on
+      # a clean machine rather than only on the maintainer's, and the step
+      # before it proves the tag matches the manifest. What is no longer this
+      # workflow's job is publishing, unless a tag arrives without the release
+      # pipeline having run — a hand-pushed tag, which is the case this branch
+      # still covers.
+      #
+      # It never overwrites: an existing release's asset is the one that was
+      # tested and published to ARS, and a runner rebuild is not byte-identical
+      # to it.
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,6 +82,12 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           SCRIPTURE="${{ steps.scripture.outputs.version }}"
           PKG="build/dist/pkg_livingword-$VERSION.zip"
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "::notice::$TAG is already published — leaving it untouched."
+            echo "$TAG already published; this run verified the build only." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
           gh release create "$TAG" "$PKG" \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## What's failing

Every tag since **v5.6.0-beta1** has left a red **Release** run — twelve of them, two per tag. Last green was v5.5.0 in May.

```
a release with the same tag name already exists: v5.7.0-beta3
```

`composer release` (cwm-release) builds, creates the GitHub release, uploads the zip and publishes to ARS — all before the tag it pushes reaches Actions. So this workflow's `gh release create` arrives second and fails the run, **on a release that had already succeeded**.

Two runs per tag because cwm-release force-moves the tag after the changelog commit, and each push fires the workflow again.

That's the real cost here: a red X on every release that means nothing, which is exactly why it went eleven runs without being chased.

## The change

The publish step now checks for an existing release and exits cleanly when it finds one, noting it in the run summary.

**A guard rather than a deletion**, because the rest of the workflow earns its place:

- it **builds the package on a clean runner**, proving the build doesn't depend on the maintainer's machine state — something no other job does
- it **verifies the tag matches `livingword.xml`** before anything else runs
- it **still publishes** when a tag arrives that the release pipeline didn't create — a hand-pushed tag, which is the case this branch exists for

It never overwrites an existing release. That asset is the one that was tested and published to ARS, and a runner rebuild isn't byte-identical to it.

## Verification

The workflow only triggers on `v*` tags, so this can't be exercised by a PR. The guard's two paths were checked directly against the API:

```
existing tag (v5.7.0-beta3) -> skip path
absent tag  (v9.9.9-nope)   -> falls through to create
```

The next release cut will be the first green Release run since May.

🤖 Generated with [Claude Code](https://claude.com/claude-code)