### PR TITLE
test(e2e): pin that Joomla can see the task plugin's three routines

### DIFF
--- a/tests/e2e/admin/task-plugin.spec.js
+++ b/tests/e2e/admin/task-plugin.spec.js
@@ -1,0 +1,67 @@
+/**
+ * The scheduled task plugin, as far as it can be taken without sending mail.
+ *
+ * plg_task_livingword carries the three routines the component's email
+ * delivery hangs off: the daily reading email, the weekly progress digest and
+ * the accountability-partner digest. Nothing has ever asserted that Joomla can
+ * see them, and the failure mode is silence — #114 shipped a release where the
+ * webservices plugin installed disabled, and this plugin's own install script
+ * exists because Joomla registers plugins disabled and "an admin can configure
+ * the email settings, create a scheduled task, and still get silence".
+ *
+ * Two things are pinned here, both about reachability rather than delivery:
+ * the plugin is enabled, and Joomla's scheduler offers all three routines when
+ * an admin goes to create a task.
+ *
+ * DELIBERATELY NOT RUN: executing a routine sends real email to every
+ * subscriber with email = 1. The dev site is configured with live SMTP
+ * (mailonline = true, a real relay and a real from-address), so a spec that
+ * ran the daily-email routine would mail actual people. Covering execution
+ * needs a site whose mail goes to a catcher, or mailonline = false, and that
+ * is a decision about the environment rather than something a test should
+ * assume.
+ *
+ * @package  Livingword.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const PLUGINS = 'administrator/index.php?option=com_plugins';
+const SCHEDULER_NEW = 'administrator/index.php?option=com_scheduler&view=select&layout=default';
+
+const ROUTINES = [
+    'LivingWord: Send Daily Reading Emails',
+    'LivingWord: Send Weekly Progress Digest',
+    'LivingWord: Send Weekly Partner Progress Digest',
+];
+
+test.describe('Task plugin registration @admin', () => {
+    test('the plugin is installed and enabled', async ({ page }) => {
+        // Asked as a filter rather than by reading a status icon: "appears when
+        // filtering for enabled plugins" is the same claim, and it does not
+        // depend on how Joomla renders that column this version.
+        await page.goto(
+            `${PLUGINS}&filter%5Bsearch%5D=livingword&filter%5Bfolder%5D=task&filter%5Benabled%5D=1`
+        );
+
+        await expect(
+            page.locator('#pluginList tbody tr, #adminForm tbody tr'),
+            'the task plugin is listed among the enabled plugins'
+        ).not.toHaveCount(0);
+    });
+
+    test('the scheduler offers all three LivingWord routines', async ({ page }) => {
+        await page.goto(SCHEDULER_NEW);
+
+        // The routine picker is what an admin meets when creating a task. A
+        // routine missing here is a plugin Joomla cannot see, and the symptom
+        // on a live site is email that simply never arrives.
+        for (const routine of ROUTINES) {
+            await expect(
+                page.locator(`text=${routine}`),
+                `${routine} is offered`
+            ).not.toHaveCount(0);
+        }
+    });
+});


### PR DESCRIPTION
`plg_task_livingword` carries the routines every outbound email hangs off — daily reading email, weekly progress digest, accountability-partner digest — and **nothing has ever asserted that Joomla can see them**.

The failure mode is silence, and this project has shipped it before: #114 released a package whose webservices plugin installed disabled. This plugin's own install script exists for the same reason, in its words — Joomla registers plugins disabled, so "an admin can configure the email settings, create a scheduled task, and still get silence".

## Two specs, both about reachability

- the plugin is listed when filtering for **enabled** task plugins
- Joomla's scheduler offers **all three routines** on the screen where an admin creates a task

Enabledness is asked as a *filter* rather than read off a status icon — the same claim, without depending on how Joomla renders that column this version.

Both were checked against their negatives before committing, because an assertion that can't fail is worse than none:

| check | result |
|---|---|
| nonexistent plugin name | 0 rows |
| the real plugin, filtered to **disabled** | 0 rows |
| invented routine title | 0 matches |
| real routine title | 1 match |

## Execution is deliberately not covered

Running a routine sends real email to every subscriber with `email = 1`. **The dev site is configured with live SMTP** — `mailonline = true`, a real relay, a real from-address — so a spec that ran the daily-email routine would mail actual people. The disposable test site attempts delivery too (`mailer = 'mail'`).

Covering execution needs a site whose mail goes to a catcher (Mailpit/MailHog), or `mailonline = false`. That's a decision about the environment, not something a test should quietly assume, so the reason is recorded in the spec rather than worked around.

Worth noting what that would unlock beyond the routines themselves: captured mail is also the only honest source of valid `cwmcomplete` and `cwmunsubscribe` tokens, which #131 had to leave uncovered.

## Verification

**61 passed, 2 skipped** across the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)