### PR TITLE
fix(install): repair the preference columns older sites never got

### DIFF
--- a/script.php
+++ b/script.php
@@ -146,6 +146,7 @@ class Com_livingwordInstallerScript
             $this->registerContentTypes();
 
             $this->ensureActionTokenIndex();
+            $this->ensureUserPreferenceColumns();
 
             // Tell lib_cwmscripture this component depends on it, so removing
             // the library is refused while Living Word is installed.
@@ -171,6 +172,7 @@ class Com_livingwordInstallerScript
             $this->registerContentTypes();
 
             $this->ensureActionTokenIndex();
+            $this->ensureUserPreferenceColumns();
 
             // Idempotent, and the repair path for a fresh package install where
             // the library child had not been stored yet at our postflight.
@@ -231,6 +233,78 @@ class Com_livingwordInstallerScript
         }
 
         ConsumerRegistry::unregister('com_livingword', 'component');
+    }
+
+    /**
+     * Ensure #__livingword_users carries the three preference columns.
+     *
+     * audio_version, email_hour and timezone are in install.mysql.utf8.sql and
+     * in no update file, so a site created before they were added never got
+     * them — and nothing said so. Joomla's DatabaseDriver::updateObject() reads
+     * the table's real columns and silently skips any property that is not one,
+     * so saving preferences answered "Your preferences have been saved" and
+     * dropped these three every time. Observed on two dev installs; a package
+     * install has them, which is why it never showed up in testing.
+     *
+     * email_hour is the one that bites hardest: the task plugin only mails
+     * subscribers whose hour matches the current server hour, so on an affected
+     * site the daily email goes out at whatever hour the row happens to hold
+     * and the reader cannot change it.
+     *
+     * In PHP rather than an update file for two reasons. Joomla runs update SQL
+     * only when it is newer than the recorded schema version, so a site already
+     * past this version would never see it — the same reason
+     * ensureActionTokenIndex() exists. And MySQL has no ADD COLUMN IF NOT
+     * EXISTS, so a plain ALTER would fail on every site that is already fine.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function ensureUserPreferenceColumns(): void
+    {
+        $columns = [
+            'audio_version' => "varchar(20) NOT NULL DEFAULT '' COMMENT 'Preferred audio bible version'",
+            'email_hour'    => "tinyint NOT NULL DEFAULT 6 COMMENT 'Preferred email hour (0-23)'",
+            'timezone'      => "varchar(50) NOT NULL DEFAULT '' COMMENT 'User timezone (e.g. America/Chicago)'",
+        ];
+
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $table = $db->replacePrefix('#__livingword_users');
+
+            foreach ($columns as $column => $definition) {
+                $query = $db->getQuery(true)
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('information_schema.columns'))
+                    ->where($db->quoteName('table_schema') . ' = DATABASE()')
+                    ->where($db->quoteName('table_name') . ' = ' . $db->quote($table))
+                    ->where($db->quoteName('column_name') . ' = ' . $db->quote($column));
+
+                if ((int) $db->setQuery($query)->loadResult() > 0) {
+                    continue;
+                }
+
+                // The definition is a literal from the array above, never user
+                // input, and column definitions cannot be bound as parameters.
+                $db->setQuery(
+                    'ALTER TABLE ' . $db->quoteName($table)
+                    . ' ADD COLUMN ' . $db->quoteName($column) . ' ' . $definition
+                )->execute();
+
+                Factory::getApplication()->enqueueMessage(
+                    sprintf('CWM LivingWord: added the missing %s column to #__livingword_users.', $column),
+                    'message'
+                );
+            }
+        } catch (\Throwable $e) {
+            // Say so rather than fail the install: a missing column costs three
+            // preferences, and aborting the update would cost everything.
+            Factory::getApplication()->enqueueMessage(
+                'CWM LivingWord: could not repair the preference columns — ' . $e->getMessage(),
+                'warning'
+            );
+        }
     }
 
     /**

--- a/tests/e2e/admin/task-plugin.spec.js
+++ b/tests/e2e/admin/task-plugin.spec.js
@@ -52,16 +52,19 @@ test.describe('Task plugin registration @admin', () => {
     });
 
     test('the scheduler offers all three LivingWord routines', async ({ page }) => {
-        await page.goto(SCHEDULER_NEW);
+        // Asserted against the response com_scheduler actually sends, not the
+        // live DOM. The picker rearranges itself after load, so a DOM query
+        // races that: the same locator answered 1 on one load and 0 on the
+        // next. The server's own HTML cannot race, and it is the same claim —
+        // these routines are on the screen where an admin creates a task.
+        const response = await page.request.get(SCHEDULER_NEW);
 
-        // The routine picker is what an admin meets when creating a task. A
-        // routine missing here is a plugin Joomla cannot see, and the symptom
-        // on a live site is email that simply never arrives.
+        expect(response.status(), 'the routine picker loads').toBe(200);
+
+        const html = await response.text();
+
         for (const routine of ROUTINES) {
-            await expect(
-                page.locator(`text=${routine}`),
-                `${routine} is offered`
-            ).not.toHaveCount(0);
+            expect(html.includes(routine), `${routine} is offered`).toBeTruthy();
         }
     });
 });


### PR DESCRIPTION
Three columns are in `install.mysql.utf8.sql` and in **no update file**: `audio_version`, `email_hour`, `timezone`. A site created before they were added never got them — and nothing ever said so.

Joomla's `DatabaseDriver::updateObject()` reads the table's real columns and **silently skips** any property that isn't one (`DatabaseDriver.php:1820`). So saving preferences answered *"Your preferences have been saved"* and dropped these three every single time.

## How it surfaced

I was setting an email hour so the daily-email routine would have somebody to send to. The form posted `email_hour=15`, the page reported success, and the value came back **6**.

| site | audio_version, email_hour, timezone |
|---|---|
| j6-dev (upgraded) | **missing** |
| j5-dev (upgraded) | **missing** |
| j6-test (fresh package install) | present |

A fresh install has them, which is exactly why this never showed up in testing — every automated check runs against a freshly installed site.

**`email_hour` is the one that bites hardest.** The task plugin only mails subscribers whose preferred hour matches the current server hour, so on an affected site the daily email goes out at whatever hour the row happens to hold, and the reader cannot change it. A silent failure inside a feature whose whole failure mode is silence.

## Why the repair is in script.php

The same reason `ensureActionTokenIndex()` already documents: Joomla runs update SQL only when it's newer than the recorded schema version, so a site already past this version would never see it. MySQL also has no `ADD COLUMN IF NOT EXISTS` (that's MariaDB), so a plain `ALTER` would fail on every site that's already correct.

The check reads `information_schema` first and adds only what's missing, on both the install and update routes, and reports rather than aborts if it can't.

## Also here: a test that was green by luck

The scheduler-routine assertion queried the live DOM, and com_scheduler rearranges the picker after load — the same locator answered **1 on one load and 0 on the next**. It now asserts on the response com_scheduler actually sends: same claim, cannot race.

## Verification

Preferences persist on a repaired site (`email_hour` 6 → 15 and stays). 52 unit tests, 43 browser specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)