### PR TITLE
fix(task): send the daily email at the reader's hour, not the server's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "CWM\\Component\\Livingword\\Tests\\": "tests/unit/"
+      "CWM\\Component\\Livingword\\Tests\\": "tests/unit/",
+      "CWM\\Plugin\\Task\\Livingword\\": "plg_task_livingword/src/"
     }
   },
   "repositories": [

--- a/plg_task_livingword/src/Extension/Livingword.php
+++ b/plg_task_livingword/src/Extension/Livingword.php
@@ -19,6 +19,7 @@ use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmscriptureHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
+use CWM\Plugin\Task\Livingword\Support\LocalHour;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
@@ -90,16 +91,47 @@ class Livingword extends CMSPlugin implements SubscriberInterface
 
         $db = $this->getDatabase();
 
-        // Get users subscribed to email whose preferred hour matches now
-        $serverHour = (int) date('G');
+        // Subscribers whose preferred hour has arrived *where they are*.
+        //
+        // This used to compare email_hour against date('G'), which Joomla pins
+        // to UTC — so a reader in America/Chicago who asked for 6am was mailed
+        // at 1am, and the timezone stored on the very same row was read by
+        // nothing anywhere in the component. Matching per timezone is what
+        // makes that column mean something.
+        //
+        // Grouped by distinct timezone rather than filtered in PHP: a site has
+        // a handful of timezones and can have any number of subscribers, so
+        // this stays one query that returns only the rows that are due.
+        $now      = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $fallback = (string) $this->getApplication()->get('offset', 'UTC');
+
+        $zones = $db->setQuery(
+            $db->getQuery(true)
+                ->select('DISTINCT ' . $db->quoteName('timezone'))
+                ->from($db->quoteName('#__livingword_users'))
+                ->where($db->quoteName('email') . ' = 1')
+        )->loadColumn();
+
+        if (empty($zones)) {
+            return Status::OK;
+        }
 
         $query = $db->getQuery(true)
             ->select('a.*, u.name, u.email AS user_email')
             ->from($db->quoteName('#__livingword_users', 'a'))
             ->join('INNER', $db->quoteName('#__users', 'u') . ' ON ' . $db->quoteName('u.id') . ' = ' . $db->quoteName('a.user_id'))
             ->where($db->quoteName('a.email') . ' = 1')
-            ->where($db->quoteName('u.block') . ' = 0')
-            ->where($db->quoteName('a.email_hour') . ' = ' . $serverHour);
+            ->where($db->quoteName('u.block') . ' = 0');
+
+        $due = [];
+
+        foreach ($zones as $zone) {
+            $due[] = '(' . $db->quoteName('a.timezone') . ' = ' . $db->quote((string) $zone)
+                . ' AND ' . $db->quoteName('a.email_hour') . ' = '
+                . LocalHour::inZone((string) $zone, $fallback, $now) . ')';
+        }
+
+        $query->where('(' . implode(' OR ', $due) . ')');
 
         $db->setQuery($query);
         $subscribers = $db->loadObjectList();

--- a/plg_task_livingword/src/Support/LocalHour.php
+++ b/plg_task_livingword/src/Support/LocalHour.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @package    Livingword.Plugin
+ * @subpackage Task.Livingword
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Plugin\Task\Livingword\Support;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * What hour it is where a subscriber lives.
+ *
+ * Deliberately free of Joomla: the daily-email routine decides who to mail by
+ * comparing a stored preferred hour against the clock, and that rule was wrong
+ * for the whole life of the feature — it compared against date('G'), which
+ * Joomla pins to UTC, so a reader in America/Chicago who asked for 6am was
+ * mailed at 1am and the timezone stored on the same row was read by nothing.
+ *
+ * It stayed wrong because it could not be tested: the rule lived inside a
+ * plugin method that needs a database, a task event and a mailer to reach. A
+ * class with no dependencies can be exercised in a unit test at any hour of any
+ * day, including the ones where daylight saving changes the answer.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class LocalHour
+{
+    /**
+     * The hour of the day, 0-23, in the first timezone that makes sense.
+     *
+     * Falls back rather than rejects. A stored zone can outlive a tzdata
+     * update, and a reader whose zone was renamed should still get their
+     * email — at the site's hour, which is what an administrator means by
+     * "6am" for somebody who never chose.
+     *
+     * @param   string              $timezone  Subscriber timezone, possibly empty
+     * @param   string              $fallback  Site timezone to use instead
+     * @param   \DateTimeImmutable  $now       The moment being asked about
+     *
+     * @return  int  Hour of the day, 0-23
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function inZone(string $timezone, string $fallback, \DateTimeImmutable $now): int
+    {
+        foreach ([$timezone, $fallback, 'UTC'] as $candidate) {
+            if (trim($candidate) === '') {
+                continue;
+            }
+
+            try {
+                return (int) $now->setTimezone(new \DateTimeZone(trim($candidate)))->format('G');
+            } catch (\Exception) {
+                continue;
+            }
+        }
+
+        return (int) $now->format('G');
+    }
+}

--- a/tests/e2e/admin/daily-email.spec.js
+++ b/tests/e2e/admin/daily-email.spec.js
@@ -109,15 +109,21 @@ test.describe('Daily reading email @admin', () => {
             await page.goto(SETTINGS);
             test.skip(!(await page.locator('#email_hour').count()), 'preferences are not reachable for this member');
 
-            // UTC, not local. Joomla forces PHP's timezone to UTC, so the
-            // routine's date('G') is the UTC hour — and matching against the
-            // machine's local hour silently selects nobody. That is also worth
-            // knowing as a product question: the routine compares a reader's
-            // preferred hour against server time and ignores the timezone
-            // column stored next to it.
+            // The reader's timezone is pinned to UTC and the hour set in UTC,
+            // so this is deterministic wherever the runner and the site happen
+            // to be. The routine now reads each subscriber's own timezone —
+            // before that it compared against date('G'), which Joomla pins to
+            // UTC, so anyone who had chosen a zone was mailed at the wrong
+            // hour and the column was read by nothing.
             const hour = String(new Date().getUTCHours());
+            const zones = await page.locator('#timezone option').evaluateAll((o) => o.map((x) => x.value));
 
             await page.locator('#email').setChecked(true);
+
+            if (zones.includes('UTC')) {
+                await page.locator('#timezone').selectOption('UTC');
+            }
+
             await page.locator('#email_hour').selectOption(hour);
             await page.locator('#settingsForm button[type="submit"]:not([name="action"])').click();
             await page.waitForLoadState('domcontentloaded');

--- a/tests/unit/Plugin/Task/LocalHourTest.php
+++ b/tests/unit/Plugin/Task/LocalHourTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @package    Livingword.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Tests\Plugin\Task;
+
+use CWM\Plugin\Task\Livingword\Support\LocalHour;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The rule that decides whose daily email is due.
+ *
+ * Written after finding that the routine compared a reader's preferred hour
+ * against date('G') — UTC, because Joomla pins PHP there — while the timezone
+ * stored on the same row was read by nothing. A reader in Chicago asking for
+ * 6am was mailed at 1am.
+ *
+ * Every case here is a fixed instant, so the suite gives the same answer at
+ * 3am in June as at noon in December.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LocalHourTest extends TestCase
+{
+    /**
+     * 12:00 UTC on a summer day and on a winter day.
+     */
+    private const SUMMER = '2026-07-15 12:00:00';
+    private const WINTER = '2026-01-15 12:00:00';
+
+    private function at(string $utc): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable($utc, new \DateTimeZone('UTC'));
+    }
+
+    public function testUtcIsTheHourItself(): void
+    {
+        $this->assertSame(12, LocalHour::inZone('UTC', 'UTC', $this->at(self::SUMMER)));
+    }
+
+    public function testAZoneBehindUtcReadsEarlier(): void
+    {
+        // Chicago is UTC-5 in July: noon UTC is 7am there. Under the old rule
+        // this reader's "7am" never matched, and their 6am mail arrived at 1am.
+        $this->assertSame(7, LocalHour::inZone('America/Chicago', 'UTC', $this->at(self::SUMMER)));
+    }
+
+    public function testTheSameZoneShiftsWithDaylightSaving(): void
+    {
+        // UTC-6 in January, so noon UTC is 6am, not 7. A rule that stored a
+        // fixed offset instead of a zone would answer the same in both months.
+        $this->assertSame(6, LocalHour::inZone('America/Chicago', 'UTC', $this->at(self::WINTER)));
+    }
+
+    public function testAZoneAheadOfUtcReadsLater(): void
+    {
+        $this->assertSame(21, LocalHour::inZone('Asia/Tokyo', 'UTC', $this->at(self::SUMMER)));
+    }
+
+    public function testAZoneCanCrossIntoTheNextDay(): void
+    {
+        // 23:00 UTC is 08:00 the following morning in Tokyo. The hour is what
+        // matters, and it must come from the reader's calendar day, not ours.
+        $this->assertSame(8, LocalHour::inZone('Asia/Tokyo', 'UTC', $this->at('2026-07-15 23:00:00')));
+    }
+
+    public function testAnEmptyZoneUsesTheSiteZone(): void
+    {
+        // Most rows have no timezone: the column was never populated, because
+        // nothing read it. Those readers get the site's hour, which is what an
+        // administrator means by "6am".
+        $this->assertSame(7, LocalHour::inZone('', 'America/Chicago', $this->at(self::SUMMER)));
+    }
+
+    public function testWhitespaceCountsAsEmpty(): void
+    {
+        $this->assertSame(7, LocalHour::inZone('   ', 'America/Chicago', $this->at(self::SUMMER)));
+    }
+
+    public function testAnUnknownZoneFallsBackRatherThanFailing(): void
+    {
+        // A stored zone can outlive a tzdata rename. Losing the email would be
+        // a worse answer than sending it at the site's hour.
+        $this->assertSame(7, LocalHour::inZone('Mars/Olympus_Mons', 'America/Chicago', $this->at(self::SUMMER)));
+    }
+
+    public function testBothUnusableFallsBackToUtc(): void
+    {
+        $this->assertSame(12, LocalHour::inZone('Nowhere/Here', 'Also/Nowhere', $this->at(self::SUMMER)));
+    }
+
+    public function testAnOffsetStyleZoneIsAccepted(): void
+    {
+        // Joomla's own timezone list is region-based, but a hand-edited row or
+        // an older site can hold an offset. It is a valid DateTimeZone.
+        $this->assertSame(14, LocalHour::inZone('+02:00', 'UTC', $this->at(self::SUMMER)));
+    }
+
+    public function testTheAnswerIsAlwaysAnHourOfTheDay(): void
+    {
+        foreach (\DateTimeZone::listIdentifiers() as $zone) {
+            $hour = LocalHour::inZone($zone, 'UTC', $this->at(self::SUMMER));
+
+            $this->assertGreaterThanOrEqual(0, $hour, $zone);
+            $this->assertLessThanOrEqual(23, $hour, $zone);
+        }
+    }
+}


### PR DESCRIPTION
The routine picked subscribers with:

```php
WHERE email_hour = date('G')
```

Joomla pins PHP to UTC, so **"6am" meant 6am UTC for everybody**. A reader in America/Chicago who asked for 6am was mailed at 1am — midnight in summer.

The `timezone` column on the same row — offered by the preferences form, saved by the model, declared on the table — was **read by nothing, anywhere in the component**. Write-only data.

## The fix

Selection is grouped by distinct timezone: still one query returning only the rows that are due, bounded by how many zones a site uses rather than how many subscribers it has. A row with no timezone falls back to the site's configured zone — what an administrator means by "6am" for a reader who never chose, and most rows are in that state precisely *because* nothing ever read the column.

## Why it stayed wrong

The rule lived inside a plugin method that needs a database, a task event and a mailer to reach, so nothing could exercise it. It now lives in `LocalHour`, free of Joomla, and **eleven unit tests** cover it at fixed instants so they answer the same in June and December:

- a zone behind UTC, and the **daylight-saving shift** a stored offset would have got wrong
- a zone crossing into the **next day** (23:00 UTC is 08:00 in Tokyo)
- empty and whitespace zones falling back to the site's
- an **unknown** zone falling back rather than losing the email — a stored zone can outlive a tzdata rename
- every zone PHP knows returning an hour in 0–23

## Proven end to end

Against the mail catcher, same subscriber both ways:

| timezone | preferred hour | result |
|---|---|---|
| America/Chicago | the **UTC** hour | no mail |
| America/Chicago | **Chicago's** hour | **delivered** |

The old code did exactly the opposite. The e2e spec now pins the reader's timezone to UTC so it stays deterministic wherever the runner and the site happen to be.

## Verification

63 unit tests, 64 e2e specs, `composer lint` and `npm run lint:js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)