### PR TITLE
test(e2e): cover the weekly progress digest, and share the mail machinery

### DIFF
--- a/tests/e2e/admin/daily-email.spec.js
+++ b/tests/e2e/admin/daily-email.spec.js
@@ -22,65 +22,13 @@
  */
 
 const { test, expect } = require('@playwright/test');
+const { catcherAvailable, clearInbox, waitForMail, messageBody } = require('../helpers/mailpit');
+const { ensureTask, runTask } = require('../helpers/scheduler');
 
-const MAILPIT = process.env.MAILPIT_URL || 'http://127.0.0.1:8025';
+const ROUTINE = 'livingword.email_notifications';
+const TITLE   = 'E2E Daily Reading Emails';
 
-const TASKS = 'administrator/index.php?option=com_scheduler&view=tasks'
-    + '&filter%5Bsearch%5D=&filter%5Bstate%5D=';
 const SETTINGS = 'index.php?option=com_livingword&view=cwmsettings';
-
-/**
- * Whether a mail catcher is listening, and its inbox is readable.
- *
- * @param   {object}  request  Playwright APIRequestContext
- *
- * @returns {Promise<boolean>}
- */
-async function catcherAvailable(request) {
-    try {
-        const res = await request.get(`${MAILPIT}/api/v1/info`, { timeout: 3000 });
-
-        return res.ok();
-    } catch {
-        return false;
-    }
-}
-
-/**
- * Empty the catcher, so what arrives next can only be what this test caused.
- *
- * @param   {object}  request  Playwright APIRequestContext
- *
- * @returns {Promise<void>}
- */
-async function clearInbox(request) {
-    await request.delete(`${MAILPIT}/api/v1/messages`);
-}
-
-/**
- * Wait for a captured message, since delivery is asynchronous to the click.
- *
- * @param   {object}  request  Playwright APIRequestContext
- * @param   {number}  timeout  Milliseconds to keep asking
- *
- * @returns {Promise<Array>}   Message summaries, newest first
- */
-async function waitForMail(request, timeout = 20000) {
-    const deadline = Date.now() + timeout;
-
-    for (;;) {
-        const res = await request.get(`${MAILPIT}/api/v1/messages?limit=20`);
-        const body = res.ok() ? await res.json() : { messages: [] };
-
-        if ((body.messages || []).length || Date.now() > deadline) {
-            return body.messages || [];
-        }
-
-        await new Promise((resolve) => {
-            setTimeout(resolve, 500);
-        });
-    }
-}
 
 test.describe('Daily reading email @admin', () => {
     test.describe.configure({ mode: 'serial' });
@@ -88,7 +36,7 @@ test.describe('Daily reading email @admin', () => {
     test.beforeEach(async ({ request }) => {
         test.skip(
             !(await catcherAvailable(request)),
-            `no mail catcher on ${MAILPIT} — refusing to run a routine that would email real subscribers`
+            'no mail catcher listening — refusing to run a routine that would email real subscribers'
         );
     });
 
@@ -138,18 +86,12 @@ test.describe('Daily reading email @admin', () => {
     });
 
     test('running the task delivers a reading email', async ({ page, request }) => {
-        await page.goto(TASKS);
-
-        const row = page.locator('#adminForm tbody tr').filter({ hasText: 'Reading Emails' }).first();
-
-        test.skip(
-            !(await row.count()),
-            'no scheduled task uses the daily-reading routine on this site'
-        );
+        // Created rather than assumed: the plugin does nothing until a task is
+        // scheduled, so on a fresh site there is none to find.
+        expect(await ensureTask(page, ROUTINE, TITLE), 'a task for the routine exists').toBeTruthy();
 
         await clearInbox(request);
-
-        await row.locator('button:has-text("Run Task")').click();
+        await runTask(page, TITLE);
 
         const messages = await waitForMail(request);
 
@@ -165,9 +107,7 @@ test.describe('Daily reading email @admin', () => {
 
         test.skip(!messages.length, 'no message captured by the previous test');
 
-        const res = await request.get(`${MAILPIT}/api/v1/message/${messages[0].ID}`);
-        const body = await res.json();
-        const html = `${body.HTML || ''}${body.Text || ''}`;
+        const html = await messageBody(request, messages[0].ID);
 
         // The two links every reading email carries. They are the only place
         // these tokens are ever exposed, which is why the landing pages could

--- a/tests/e2e/admin/weekly-digest.spec.js
+++ b/tests/e2e/admin/weekly-digest.spec.js
@@ -1,0 +1,102 @@
+/**
+ * The weekly progress digest, from scheduled task to delivered message.
+ *
+ * The second of the plugin's three routines, and the second thing about this
+ * component that nobody can see working. Unlike the daily email it has no hour
+ * to match — it takes every opted-in subscriber and reports the last seven days
+ * — so what it needs from a test is a subscriber who is opted in and a task to
+ * run.
+ *
+ * Creates the task itself rather than assuming one exists, because on a fresh
+ * site there is none: the plugin does nothing until an administrator schedules
+ * it, deliberately, and a spec that quietly skipped there would be testing
+ * whoever last used the dev site rather than the component.
+ *
+ * Requires a mail catcher; skips cleanly without one.
+ *
+ * @package  Livingword.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+const { test, expect } = require('@playwright/test');
+const { catcherAvailable, clearInbox, waitForMail, messageBody } = require('../helpers/mailpit');
+const { ensureTask, runTask } = require('../helpers/scheduler');
+
+const ROUTINE = 'livingword.weekly_digest';
+const TITLE   = 'E2E Weekly Progress Digest';
+
+const SETTINGS = 'index.php?option=com_livingword&view=cwmsettings';
+
+test.describe('Weekly progress digest @admin', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async ({ request }) => {
+        test.skip(
+            !(await catcherAvailable(request)),
+            'no mail catcher listening — refusing to run a routine that would email real subscribers'
+        );
+    });
+
+    test('a subscriber is opted in to receive it', async ({ browser, baseURL }) => {
+        const ctx = await browser.newContext({
+            ignoreHTTPSErrors: true,
+            storageState: 'tests/e2e/.auth/member-j6.json',
+            baseURL,
+        });
+
+        try {
+            const page = await ctx.newPage();
+
+            await page.goto(SETTINGS);
+            test.skip(!(await page.locator('#email').count()), 'preferences are not reachable for this member');
+
+            // No hour to match here — the digest goes to everyone opted in, so
+            // the opt-in is the whole precondition.
+            await page.locator('#email').setChecked(true);
+            await page.locator('#settingsForm button[type="submit"]:not([name="action"])').click();
+            await page.waitForLoadState('domcontentloaded');
+
+            await page.goto(SETTINGS);
+            await expect(page.locator('#email')).toBeChecked();
+        } finally {
+            await ctx.close();
+        }
+    });
+
+    test('the routine can be scheduled', async ({ page }) => {
+        expect(
+            await ensureTask(page, ROUTINE, TITLE),
+            'a task for the weekly digest routine exists'
+        ).toBeTruthy();
+    });
+
+    test('running it delivers a digest', async ({ page, request }) => {
+        await clearInbox(request);
+        await runTask(page, TITLE);
+
+        const messages = await waitForMail(request);
+
+        expect(messages.length, 'the routine delivered a message').toBeGreaterThan(0);
+
+        const subjects = messages.map((m) => m.Subject).join(' | ');
+
+        expect(subjects, `subjects seen: ${subjects}`).toMatch(/progress|digest|week/i);
+    });
+
+    test('the digest reports the week rather than a single day', async ({ request }) => {
+        const messages = await waitForMail(request, 2000);
+
+        test.skip(!messages.length, 'no message captured by the previous test');
+
+        const html = await messageBody(request, messages[0].ID);
+
+        // What separates this from the daily email: it summarises a period, so
+        // it has to carry progress figures. A digest that rendered an empty
+        // shell would still have been "delivered" by the test above.
+        expect(html.length, 'the digest has a body').toBeGreaterThan(200);
+        expect(html, 'it reports something countable').toMatch(/\d/);
+
+        // And it must offer the way out that every bulk email needs.
+        expect(html, 'it carries an unsubscribe link').toMatch(/cwmunsubscribe\.unsubscribe/);
+    });
+});

--- a/tests/e2e/helpers/mailpit.js
+++ b/tests/e2e/helpers/mailpit.js
@@ -1,0 +1,87 @@
+/**
+ * Talking to the mail catcher.
+ *
+ * Every spec that exercises outbound mail needs the same four things: is a
+ * catcher listening, empty it, wait for what arrives, read one message. Shared
+ * here so a second mail spec cannot drift from the first — and so the refusal
+ * to run without a catcher is written once, in one place, since the
+ * alternative to a catcher is a test that emails real subscribers.
+ *
+ * Mailpit by default; anything exposing the same REST shape would do.
+ * Override the location with MAILPIT_URL.
+ *
+ * @package  Livingword.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+const MAILPIT = process.env.MAILPIT_URL || 'http://127.0.0.1:8025';
+
+/**
+ * Whether a catcher is listening and its inbox is readable.
+ *
+ * @param   {object}  request  Playwright APIRequestContext
+ *
+ * @returns {Promise<boolean>}
+ */
+async function catcherAvailable(request) {
+    try {
+        const res = await request.get(`${MAILPIT}/api/v1/info`, { timeout: 3000 });
+
+        return res.ok();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Empty the inbox, so what arrives next can only be what the test caused.
+ *
+ * @param   {object}  request  Playwright APIRequestContext
+ *
+ * @returns {Promise<void>}
+ */
+async function clearInbox(request) {
+    await request.delete(`${MAILPIT}/api/v1/messages`);
+}
+
+/**
+ * Wait for captured mail, since delivery is asynchronous to the click.
+ *
+ * @param   {object}  request  Playwright APIRequestContext
+ * @param   {number}  timeout  Milliseconds to keep asking
+ *
+ * @returns {Promise<Array>}   Message summaries, newest first
+ */
+async function waitForMail(request, timeout = 20000) {
+    const deadline = Date.now() + timeout;
+
+    for (;;) {
+        const res = await request.get(`${MAILPIT}/api/v1/messages?limit=20`);
+        const body = res.ok() ? await res.json() : { messages: [] };
+
+        if ((body.messages || []).length || Date.now() > deadline) {
+            return body.messages || [];
+        }
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 500);
+        });
+    }
+}
+
+/**
+ * The full body of one captured message, HTML and text concatenated.
+ *
+ * @param   {object}  request  Playwright APIRequestContext
+ * @param   {string}  id       Mailpit message id
+ *
+ * @returns {Promise<string>}
+ */
+async function messageBody(request, id) {
+    const res = await request.get(`${MAILPIT}/api/v1/message/${id}`);
+    const body = await res.json();
+
+    return `${body.HTML || ''}${body.Text || ''}`;
+}
+
+module.exports = { MAILPIT, catcherAvailable, clearInbox, waitForMail, messageBody };

--- a/tests/e2e/helpers/scheduler.js
+++ b/tests/e2e/helpers/scheduler.js
@@ -1,0 +1,89 @@
+/**
+ * Driving Joomla's scheduler from a spec.
+ *
+ * The task plugin does nothing until a scheduled task exists — deliberately, as
+ * its install script explains. So a mail spec has to be able to create the task
+ * it needs rather than assume somebody made one by hand, or it silently tests
+ * nothing on a fresh site.
+ *
+ * @package  Livingword.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+const ADMIN = 'administrator/index.php?option=com_scheduler';
+
+const TASKS = `${ADMIN}&view=tasks&filter%5Bsearch%5D=&filter%5Bstate%5D=`;
+
+/**
+ * Find the task row for a routine, creating the task when there is none.
+ *
+ * Creation goes through the same screens an administrator uses: the routine
+ * picker's own link, then the task form. An execution rule has to be filled in
+ * or the form refuses to save ("Invalid field: Interval in Minutes"), which is
+ * worth knowing — the rule is irrelevant to a test that runs the task by hand,
+ * but the form does not care.
+ *
+ * @param   {object}  page     Playwright page, authenticated as an administrator
+ * @param   {string}  routine  e.g. "livingword.weekly_digest"
+ * @param   {string}  title    Title to give a task this creates
+ *
+ * @returns {Promise<boolean>}  Whether a task for the routine now exists
+ */
+async function ensureTask(page, routine, title) {
+    await page.goto(TASKS);
+
+    if (await page.locator(`#adminForm tbody tr:has-text("${title}")`).count()) {
+        return true;
+    }
+
+    await page.goto(`${ADMIN}&task=task.add&type=${encodeURIComponent(routine)}`);
+
+    if (!(await page.locator('#jform_title').count())) {
+        return false;
+    }
+
+    await page.fill('#jform_title', title);
+
+    const ruleType = page.locator('#jform_execution_rules_rule_type');
+
+    if (await ruleType.count()) {
+        await ruleType.selectOption('interval-hours');
+        await page.waitForTimeout(500);
+    }
+
+    for (const id of await page.locator('input[id*="interval"]:visible').evaluateAll((els) => els.map((e) => e.id))) {
+        await page.locator(`#${id}`).fill('24');
+    }
+
+    const navigated = page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {});
+
+    await page.evaluate(() => window.Joomla.submitbutton('task.save'));
+    await navigated;
+
+    await page.goto(TASKS);
+
+    return (await page.locator(`#adminForm tbody tr:has-text("${title}")`).count()) > 0;
+}
+
+/**
+ * Run a task now, from the list's own Run Task button.
+ *
+ * The CLI runner would be the obvious choice and is not usable here: on any
+ * site with Proclaim installed, `scheduler:run` dies before any task executes
+ * (Proclaim#1787), including for core tasks. The admin button is the path that
+ * works.
+ *
+ * @param   {object}  page   Playwright page, authenticated as an administrator
+ * @param   {string}  title  Task title to run
+ *
+ * @returns {Promise<void>}
+ */
+async function runTask(page, title) {
+    await page.goto(TASKS);
+
+    const row = page.locator('#adminForm tbody tr').filter({ hasText: title }).first();
+
+    await row.locator('button:has-text("Run Task")').click();
+}
+
+module.exports = { TASKS, ensureTask, runTask };


### PR DESCRIPTION
The second of the plugin's three routines, and the second thing about this component nobody can see working.

Unlike the daily email it matches **no hour** — it takes every opted-in subscriber and reports the last seven days — so all a test needs is an opted-in reader and a task to run.

## Four specs

| spec | what it pins |
|---|---|
| a subscriber is opted in | the only precondition the routine has |
| the routine can be scheduled | com_scheduler accepts it and the task saves |
| running it delivers a digest | a message actually arrives |
| it reports a period, not a day | body present, something countable in it, **and an unsubscribe link** |

That last one earns its place: *"a message arrived"* would pass against an empty shell.

## The task is created, not assumed

On a fresh site there is none — the plugin does nothing until an administrator schedules it, by design — so a spec that skipped there would be testing whoever last used the dev site rather than the component. The daily-email spec now creates its own too, instead of depending on the one I made by hand while building it.

## Shared machinery

Mailpit and scheduler handling moved into `tests/e2e/helpers/`, so a second mail spec can't drift from the first and the **refusal to run without a catcher is written once**.

The scheduler helper records two things learned the hard way:

- the task form rejects a save without an execution rule (*"Invalid field: Interval in Minutes"*), which is irrelevant to a hand-run task but not to the form
- **the CLI runner cannot be used at all** on a site with Proclaim installed — `scheduler:run` dies before any task executes, including core ones (Proclaim#1787) — which is why these specs drive the admin button

## Verification

**68 passed, 2 skipped** across the whole suite. Nothing product-side needed fixing: the digest worked first time.

## Still uncovered

The third routine, the accountability-partner digest, needs **two** mutually-paired members. That's a second seeded account and a pairing flow through the preferences form — a bigger fixture than this tranche, and the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)