### PR TITLE
fix(module): declare the namespace without the client segment

### DIFF
--- a/mod_livingword/mod_livingword.xml
+++ b/mod_livingword/mod_livingword.xml
@@ -9,7 +9,7 @@
     <version>5.7.0-beta4</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_LIVINGWORD_XML_DESCRIPTION</description>
-    <namespace path="src">CWM\Module\Livingword\Site</namespace>
+    <namespace path="src">CWM\Module\Livingword</namespace>
 
     <compatibility>
         <cms>


### PR DESCRIPTION
Joomla appends the application segment itself when it builds the autoloader map — `libraries/namespacemap.php:241`:

```php
$namespace .= $isAdministrator ? 'Administrator\\' : 'Site\\';
```

The manifest declared `CWM\Module\Livingword\Site`, so the map came out as:

```php
'CWM\Module\Livingword\Site\Site\' => [.../modules/mod_livingword/src]
```

No class under `CWM\Module\Livingword\Site\` — the Dispatcher and the helper, which is all of them — could ever be autoloaded.

The same doubled entry is present in the map on a **clean package install**, not only on a linked dev site, so this has been true of every install of this module. For comparison, the module that works alongside it in the same sidebar maps as `'CWM\Module\ProclaimPodcast\Site\'` — a single segment.

The declaration now omits the segment Joomla adds. The rebuilt map reads `'CWM\Module\Livingword\Site\'`, matching `services/provider.php` and the classes themselves. **No PHP changed.**

## Necessary, not sufficient

With the map corrected the module **still renders nothing** on the front end. That's filed as #140 with what has and hasn't been ruled out, rather than guessed at here.

Which is also why this PR carries no spec: a module spec today would assert something that doesn't work yet, and committing a failing test to document a bug is worse than an issue that says so plainly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)