### PR TITLE
fix(module): give the dispatcher factory the base namespace

### DIFF
--- a/mod_livingword/services/provider.php
+++ b/mod_livingword/services/provider.php
@@ -17,7 +17,10 @@ use Joomla\DI\ServiceProviderInterface;
 return new class () implements ServiceProviderInterface {
     public function register(Container $container): void
     {
-        $container->registerServiceProvider(new ModuleDispatcherFactory('\\CWM\\Module\\Livingword\\Site'));
+        // The two namespaces differ on purpose. ModuleDispatcherFactory appends the
+        // client segment itself, so it takes the base namespace; HelperFactory appends
+        // nothing, so it takes the full one. Making them match breaks one or the other.
+        $container->registerServiceProvider(new ModuleDispatcherFactory('\\CWM\\Module\\Livingword'));
         $container->registerServiceProvider(new HelperFactory('\\CWM\\Module\\Livingword\\Site\\Helper'));
         $container->registerServiceProvider(new Module());
     }

--- a/mod_livingword/src/Dispatcher/Dispatcher.php
+++ b/mod_livingword/src/Dispatcher/Dispatcher.php
@@ -32,6 +32,7 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
      *
      * @since   5.0.0
      */
+    #[\Override]
     protected function getLayoutData(): array
     {
         $data = parent::getLayoutData();
@@ -42,5 +43,22 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
         $data['reading'] = $helper->getTodayReading($data['params']);
 
         return $data;
+    }
+
+    /**
+     * The layout renders the component's day-counter and empty-state strings, and the
+     * module's own .ini does not carry them. On a page that is not a com_livingword
+     * page nothing else loads them, so the reader sees the raw COM_LIVINGWORD_* keys.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[\Override]
+    protected function loadLanguage(): void
+    {
+        parent::loadLanguage();
+
+        $this->app->getLanguage()->load('com_livingword', JPATH_SITE);
     }
 }

--- a/tests/unit/Module/ServiceProviderNamespaceTest.php
+++ b/tests/unit/Module/ServiceProviderNamespaceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @package    Livingword.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Tests\Module;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The namespaces mod_livingword hands to Joomla's service-provider factories.
+ *
+ * Written after the module rendered nothing at all for a release — not its
+ * wrapper div, not its empty-state message, no exception, nothing in any log.
+ * services/provider.php passed the dispatcher factory a namespace that already
+ * carried the client segment, and ModuleDispatcherFactory::createDispatcher()
+ * appends that segment itself, so it looked for a Site\Site\Dispatcher\Dispatcher
+ * that does not exist. class_exists() said no, the factory fell back to core's
+ * ModuleDispatcher, and that one looks for a legacy mod_livingword.php entry file
+ * we do not ship — it returns having emitted nothing. Every step is silent.
+ *
+ * The trap is that the two factories take namespaces of *different depths*, so
+ * "make them consistent" is the wrong instinct and reintroduces the bug in the
+ * other direction. Both halves are asserted here.
+ *
+ * These read the real files rather than booting Joomla: the CMS is not on the
+ * unit-test autoloader, and the bug lives in a string, not in behaviour.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ServiceProviderNamespaceTest extends TestCase
+{
+    /**
+     * Repository root — the tests bootstrap points JPATH_BASE here.
+     */
+    private const ROOT = JPATH_BASE;
+
+    private function provider(): string
+    {
+        return file_get_contents(self::ROOT . '/mod_livingword/services/provider.php');
+    }
+
+    /**
+     * The single argument given to a service provider in provider.php.
+     */
+    private function namespaceArgumentFor(string $factory): string
+    {
+        $pattern = '/new\s+' . preg_quote($factory, '/') . "\(\s*'([^']+)'\s*\)/";
+
+        $this->assertMatchesRegularExpression(
+            $pattern,
+            $this->provider(),
+            $factory . ' is not registered with a literal namespace in services/provider.php'
+        );
+
+        preg_match($pattern, $this->provider(), $matches);
+
+        // The file writes namespaces as escaped literals ('\\CWM\\...').
+        return stripslashes($matches[1]);
+    }
+
+    /**
+     * The class a PHP file declares, read from its namespace and class lines.
+     */
+    private function declaredClassIn(string $relativePath): string
+    {
+        $source = file_get_contents(self::ROOT . '/' . $relativePath);
+
+        preg_match('/^namespace\s+([^;]+);/m', $source, $ns);
+        preg_match('/^(?:final\s+|abstract\s+)?class\s+(\w+)/m', $source, $class);
+
+        return '\\' . trim($ns[1]) . '\\' . $class[1];
+    }
+
+    /**
+     * ModuleDispatcherFactory takes the BASE namespace, because
+     * createDispatcher() appends '\Site' (or '\Administrator') itself before
+     * '\Dispatcher\Dispatcher'. Core does the same: mod_articles_news passes
+     * '\Joomla\Module\ArticlesNews', not '...\ArticlesNews\Site'.
+     */
+    public function testTheDispatcherNamespaceResolvesToOurDispatcher(): void
+    {
+        $base = $this->namespaceArgumentFor('ModuleDispatcherFactory');
+
+        // libraries/src/Dispatcher/ModuleDispatcherFactory.php, verbatim.
+        $resolved = '\\' . trim($base, '\\') . '\\Site\\Dispatcher\\Dispatcher';
+
+        $this->assertSame(
+            $this->declaredClassIn('mod_livingword/src/Dispatcher/Dispatcher.php'),
+            $resolved,
+            'Joomla would look for ' . $resolved . ', which no file declares, and fall back '
+            . 'to core ModuleDispatcher — the module then renders nothing, silently.'
+        );
+    }
+
+    /**
+     * HelperFactory appends nothing but the helper name, so it takes the FULL
+     * namespace down to \Site\Helper.
+     */
+    public function testTheHelperNamespaceResolvesToOurHelper(): void
+    {
+        $base = $this->namespaceArgumentFor('HelperFactory');
+
+        // libraries/src/Helper/HelperFactory.php: namespace . '\\' . $name.
+        $resolved = '\\' . trim($base, '\\') . '\\LivingwordHelper';
+
+        $this->assertSame(
+            $this->declaredClassIn('mod_livingword/src/Helper/LivingwordHelper.php'),
+            $resolved,
+            'getHelper(\'LivingwordHelper\') would throw for ' . $resolved . '.'
+        );
+    }
+
+    /**
+     * The fallback path that made the original bug invisible: core's
+     * ModuleDispatcher runs modules/mod_livingword/mod_livingword.php and
+     * returns quietly when it is absent. We ship the dispatcher pattern and no
+     * such entry file, so there is no safety net to catch a namespace slip —
+     * which is the whole reason the assertions above exist.
+     */
+    public function testWeShipNoLegacyEntryFileToFallBackOn(): void
+    {
+        $this->assertFileDoesNotExist(
+            self::ROOT . '/mod_livingword/mod_livingword.php',
+            'An entry file here would mask a broken dispatcher namespace instead of exposing it.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #140.

## The cause

`mod_livingword/services/provider.php` passed the dispatcher factory a namespace that already carried the client segment:

```php
new ModuleDispatcherFactory('\\CWM\\Module\\Livingword\\Site')
```

`ModuleDispatcherFactory::createDispatcher()` appends that segment itself (`libraries/src/Dispatcher/ModuleDispatcherFactory.php`):

```php
$name = 'Site';   // or 'Administrator'
$className = '\\' . trim($this->namespace, '\\') . '\\' . $name . '\\Dispatcher\\Dispatcher';
```

So Joomla looked for `\CWM\Module\Livingword\Site\Site\Dispatcher\Dispatcher` — the same doubled-segment mistake #139 fixed in the manifest, left untouched in the provider. Core does it right: `mod_articles_news` passes `'\Joomla\Module\ArticlesNews'`, no client segment.

## Why it was completely silent

`class_exists()` fails, so the factory falls back to `ModuleDispatcher::class`, whose `dispatch()` is:

```php
$path = JPATH_BASE . '/modules/mod_livingword/mod_livingword.php';
if (!is_file($path)) { return; }
```

We ship the dispatcher pattern and no legacy entry file, so it returns having emitted nothing. A real object was returned, so `if ($dispatcher)` passed — no exception, no log, no wrapper div, not even the "no plan" branch.

## Corrections to the issue

- **"A falsy dispatcher is a silent no-op" is impossible.** `Module::getDispatcher()` is typed `: DispatcherInterface`, non-nullable. The same goes for the other documented silent path — `AbstractModuleDispatcher::dispatch()` stops when `getLayoutData()` returns `false`, but our override is typed `: array`. Neither was ever the mechanism; worth recording so nobody re-walks it.
- **The manifest is fine.** `<folder module="mod_livingword">services</folder>`, flagged as suspicious, is byte-for-byte what core modules carry.

## The fix, and the trap in it

```php
new ModuleDispatcherFactory('\\CWM\\Module\\Livingword');           // base namespace
new HelperFactory('\\CWM\\Module\\Livingword\\Site\\Helper');       // full namespace, unchanged
```

The asymmetry is deliberate — `ModuleDispatcherFactory` appends the client segment, `HelperFactory` appends nothing but the helper name. Making them match breaks one or the other, so a comment says so and the spec asserts both halves.

I also grepped the other providers: `admin/services/provider.php` passes `'\CWM\Component\Livingword'` correctly. Nothing else is affected.

## Second defect, found by the first real render

With the module finally rendering, the day counter came out as a raw `COM_LIVINGWORD_DAY_OF`. The layout uses the component's day-counter and empty-state strings, the module's own `.ini` does not carry them, and on a page that is not a `com_livingword` page nothing else loads them. The dispatcher now loads `com_livingword` alongside its own file, reusing translations that already exist in all fourteen languages rather than duplicating two strings across them. The module already depends on the component's helpers, so this adds no new coupling.

Also added the missing `#[\Override]` on `getLayoutData()`, per the project standard.

## The spec

`tests/unit/Module/ServiceProviderNamespaceTest.php` reads the real provider, applies core's className rule, and asserts the result against the class the dispatcher file actually declares — plus the mirror assertion for the helper, and a guard that we ship no legacy entry file to mask a future slip. It reads files rather than booting Joomla: the CMS is not on the unit-test autoloader, and the bug lives in a string.

Verified failing on the old provider:

```
1) ServiceProviderNamespaceTest::testTheDispatcherNamespaceResolvesToOurDispatcher
-'\CWM\Module\Livingword\Site\Dispatcher\Dispatcher'
+'\CWM\Module\Livingword\Site\Site\Dispatcher\Dispatcher'
```

## Testing

- [x] `composer test` — 66 tests, 1762 assertions, green
- [x] `composer lint` — 0 of 100 files need fixing
- [x] `composer lint:syntax` — clean
- [x] Verified in the browser on **j6-dev**: the module renders in `sidebar-right` with "Day 1 of 365 / Genesis 1-3" and the passage text

> [!NOTE]
> Verify on **j6-dev**, not j5-dev. j5-dev's `administrator/cache/autoload_psr4.php` still reads `CWM\Module\Livingword\Site\Site\` — #139's manifest fix never propagated there, so testing on j5 without regenerating the map gives a false negative on a correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
