### PR TITLE
fix(schema): repair the progress unique key on upgraded sites

### DIFF
--- a/admin/sql/updates/mysql/5.7.0.sql
+++ b/admin/sql/updates/mysql/5.7.0.sql
@@ -1,0 +1,17 @@
+-- 5.7.0: reading-progress unique key repair (#143).
+--
+-- No DDL here. Per-passage completion (#7) widened the unique key on
+-- #__livingword_progress from (user_id, plan_id, day) to include
+-- passage_index, in install.mysql.utf8.sql only — so a site that installed
+-- before #7 and upgraded still holds one passage per day and silently drops
+-- every later tick.
+--
+-- The repair runs in script.php::ensureProgressPassageKey() instead, for the
+-- reasons ensureActionTokenIndex() and ensureUserPreferenceColumns() already
+-- document: Joomla runs an update file only when it is newer than the recorded
+-- #__schemas version, so a site already past this version would never see it,
+-- and MySQL has no DROP/ADD INDEX IF EXISTS — a plain ALTER would fail on every
+-- site whose key is already correct, which is every fresh install since #7.
+--
+-- build/verify-migrations.php asserts the resulting key shape, including that
+-- the three-column index is no longer UNIQUE.

--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -50,7 +50,12 @@ require $root . '/libraries/vendor/autoload.php';
  *
  * `tables`  — must exist.
  * `columns` — table => [column, ...] that must exist on it.
- * `indexes` — table => [index, ...] that must exist on it.
+ * `indexes` — table => [index, ...] that must exist on it, or
+ *             table => [index => ['unique' => bool, 'columns' => [...]], ...]
+ *             when the index's shape matters and not just its presence. #143 is
+ *             why the shape form exists: a site can carry the right index name
+ *             alongside a stricter one that still rejects the rows it is meant
+ *             to admit, and existence alone reports that site as healthy.
  *
  * Derived from admin/sql/updates/mysql/*.sql. A version with no DDL gets no
  * entry; the resolver falls back to the newest earlier one.
@@ -92,6 +97,35 @@ const EXPECTATIONS = [
         'indexes' => [
             'livingword_users' => ['idx_action_token'],
             'livingword_links' => ['idx_catid'],
+        ],
+    ],
+    // 5.6.0 and 5.7.0 ship their schema work in script.php postflight rather
+    // than update SQL (see those methods for why), so the entries exist to have
+    // the result asserted, not because an update file introduced it.
+    '5.7.0' => [
+        'tables'  => ['livingword_notes', 'livingword_tools'],
+        'columns' => [
+            'livingword_groups'   => ['join_mode'],
+            'livingword_users'    => ['action_token', 'audio_version', 'email_hour', 'timezone'],
+            'livingword_links'    => ['catid'],
+            'livingword_progress' => ['passage_index'],
+        ],
+        'indexes' => [
+            'livingword_users'    => ['idx_action_token'],
+            'livingword_links'    => ['idx_catid'],
+            // #143: the unique key must cover passage_index, and the
+            // three-column index must NOT be unique — either one alone still
+            // limits the site to a single passage per day.
+            'livingword_progress' => [
+                'idx_user_plan_day_passage' => [
+                    'unique'  => true,
+                    'columns' => ['user_id', 'plan_id', 'day', 'passage_index'],
+                ],
+                'idx_user_plan_day' => [
+                    'unique'  => false,
+                    'columns' => ['user_id', 'plan_id', 'day'],
+                ],
+            ],
         ],
     ],
 ];
@@ -200,12 +234,27 @@ foreach ($installs as $install) {
         continue;
     }
 
-    [$host, $user, $pass, $name, $prefix] = (static function (string $file): array {
-        require $file;
-        $c = new \JConfig();
+    // Read in a child process: every configuration.php declares a class named
+    // JConfig, so requiring a second one in this process is a fatal redeclare —
+    // which is what a run with two role=test installs used to hit.
+    $config = json_decode((string) shell_exec(sprintf(
+        '%s -r %s %s 2>/dev/null',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg(
+            'require $argv[1]; $c = new JConfig();'
+            . ' echo json_encode([$c->host, $c->user, $c->password, $c->db, $c->dbprefix]);'
+        ),
+        escapeshellarg($configFile)
+    )), true);
 
-        return [$c->host, $c->user, $c->password, $c->db, $c->dbprefix];
-    })($configFile);
+    if (!\is_array($config)) {
+        fwrite(STDERR, "  could not read {$configFile}.\n");
+        $failures++;
+
+        continue;
+    }
+
+    [$host, $user, $pass, $name, $prefix] = $config;
 
     $port = 3306;
 
@@ -267,13 +316,18 @@ foreach ($installs as $install) {
     }
 
     // 3. Indexes introduced alongside them. A missing index is silent in
-    //    normal use and only shows up as a slow query under load.
+    //    normal use and only shows up as a slow query under load — or, when the
+    //    index is a unique key, as writes the application quietly loses.
     foreach ($expected['indexes'] as $table => $indexes) {
         if (!$tableExists($table)) {
             continue;
         }
 
-        foreach ($indexes as $index) {
+        foreach ($indexes as $key => $value) {
+            // Both forms: a bare name, or name => shape.
+            $index = \is_int($key) ? $value : $key;
+            $shape = \is_int($key) ? [] : $value;
+
             $checks++;
             $res = $db->query(
                 "SHOW INDEX FROM `{$prefix}{$table}` WHERE Key_name = '" . $db->real_escape_string($index) . "'"
@@ -281,6 +335,41 @@ foreach ($installs as $install) {
 
             if (!($res instanceof mysqli_result) || $res->num_rows === 0) {
                 $fail("missing index {$table}.{$index}");
+
+                continue;
+            }
+
+            $parts = $res->fetch_all(MYSQLI_ASSOC);
+            usort($parts, static fn(array $a, array $b): int => $a['Seq_in_index'] <=> $b['Seq_in_index']);
+
+            if (isset($shape['unique'])) {
+                $checks++;
+                $isUnique = (int) $parts[0]['Non_unique'] === 0;
+
+                if ($isUnique !== $shape['unique']) {
+                    $fail(sprintf(
+                        'index %s.%s is %s, expected %s',
+                        $table,
+                        $index,
+                        $isUnique ? 'UNIQUE' : 'non-unique',
+                        $shape['unique'] ? 'UNIQUE' : 'non-unique'
+                    ));
+                }
+            }
+
+            if (isset($shape['columns'])) {
+                $checks++;
+                $columns = array_column($parts, 'Column_name');
+
+                if ($columns !== $shape['columns']) {
+                    $fail(sprintf(
+                        'index %s.%s covers (%s), expected (%s)',
+                        $table,
+                        $index,
+                        implode(', ', $columns),
+                        implode(', ', $shape['columns'])
+                    ));
+                }
             }
         }
     }

--- a/script.php
+++ b/script.php
@@ -147,6 +147,7 @@ class Com_livingwordInstallerScript
 
             $this->ensureActionTokenIndex();
             $this->ensureUserPreferenceColumns();
+            $this->ensureProgressPassageKey();
 
             // Tell lib_cwmscripture this component depends on it, so removing
             // the library is refused while Living Word is installed.
@@ -173,6 +174,7 @@ class Com_livingwordInstallerScript
 
             $this->ensureActionTokenIndex();
             $this->ensureUserPreferenceColumns();
+            $this->ensureProgressPassageKey();
 
             // Idempotent, and the repair path for a fresh package install where
             // the library child had not been stored yet at our postflight.
@@ -302,6 +304,166 @@ class Com_livingwordInstallerScript
             // preferences, and aborting the update would cost everything.
             Factory::getApplication()->enqueueMessage(
                 'CWM LivingWord: could not repair the preference columns — ' . $e->getMessage(),
+                'warning'
+            );
+        }
+    }
+
+    /**
+     * Ensure #__livingword_progress can hold one row per passage, not per day.
+     *
+     * Per-passage completion (#7) added `passage_index` and widened the unique
+     * key to cover it — in install.mysql.utf8.sql only. No update file was ever
+     * written, and CREATE TABLE IF NOT EXISTS does not alter an existing table,
+     * so every site that installed before #7 and upgraded still carries the
+     * original UNIQUE (user_id, plan_id, day). That key admits exactly one
+     * passage per day: the reader ticks passage 2, the request returns 200, and
+     * the row is rejected. Measured on a carried-forward dev install, 42 of the
+     * rows a full seed writes were refused; a fresh install refused none.
+     *
+     * Nothing complained because CwmprogressHelper::markPassageComplete()
+     * swallowed the violation as "already marked" — narrowed in this release so
+     * a genuinely lost write is no longer silent.
+     *
+     * In PHP rather than an update file for the reason ensureActionTokenIndex()
+     * gives: Joomla runs update SQL only when it is newer than the recorded
+     * schema version, and MySQL has no DROP/ADD INDEX IF EXISTS, so a plain
+     * ALTER would fail on every site that is already correct.
+     *
+     * Matched on shape, not on name — a hand-patched site may carry the narrow
+     * key under a different one — and ordered so the wide key is in place before
+     * the narrow key goes: if the ALTER fails, the table keeps the protection it
+     * had. Widening a unique key can never fail on existing data.
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    private function ensureProgressPassageKey(): void
+    {
+        $narrowColumns = ['user_id', 'plan_id', 'day'];
+        $wideColumns   = [...$narrowColumns, 'passage_index'];
+
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $table = $db->replacePrefix('#__livingword_progress');
+
+            $columnExists = $db->setQuery(
+                $db->getQuery(true)
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('information_schema.columns'))
+                    ->where($db->quoteName('table_schema') . ' = DATABASE()')
+                    ->where($db->quoteName('table_name') . ' = ' . $db->quote($table))
+                    ->where($db->quoteName('column_name') . ' = ' . $db->quote('passage_index'))
+            )->loadResult();
+
+            // An upgraded site can be missing the column as well as the key —
+            // insertObject() then fails on "unknown column" instead, which the
+            // same catch used to hide.
+            if ((int) $columnExists === 0) {
+                $db->setQuery(
+                    'ALTER TABLE ' . $db->quoteName($table)
+                    . ' ADD COLUMN ' . $db->quoteName('passage_index')
+                    . " smallint UNSIGNED NOT NULL DEFAULT 0"
+                    . " COMMENT '0-based passage index within the day reading'"
+                    . ' AFTER ' . $db->quoteName('day')
+                )->execute();
+            }
+
+            $rows = $db->setQuery(
+                $db->getQuery(true)
+                    ->select(
+                        $db->quoteName(
+                            ['index_name', 'non_unique', 'column_name'],
+                            ['name', 'nonUnique', 'column']
+                        )
+                    )
+                    ->from($db->quoteName('information_schema.statistics'))
+                    ->where($db->quoteName('table_schema') . ' = DATABASE()')
+                    ->where($db->quoteName('table_name') . ' = ' . $db->quote($table))
+                    ->order($db->quoteName('index_name') . ', ' . $db->quoteName('seq_in_index'))
+            )->loadObjectList();
+
+            $indexes = [];
+
+            foreach ($rows as $row) {
+                $indexes[$row->name]['unique']    = (int) $row->nonUnique === 0;
+                $indexes[$row->name]['columns'][] = $row->column;
+            }
+
+            $hasWide = false;
+
+            foreach ($indexes as $spec) {
+                if ($spec['unique'] && array_diff($wideColumns, $spec['columns']) === []) {
+                    $hasWide = true;
+                }
+            }
+
+            $repaired = false;
+
+            if (!$hasWide && !isset($indexes['idx_user_plan_day_passage'])) {
+                $db->setQuery(
+                    'ALTER TABLE ' . $db->quoteName($table)
+                    . ' ADD UNIQUE KEY ' . $db->quoteName('idx_user_plan_day_passage')
+                    . ' (' . implode(', ', $db->quoteName($wideColumns)) . ')'
+                )->execute();
+
+                $hasWide  = true;
+                $repaired = true;
+            }
+
+            // Only now, with the wide key in place, is it safe to give up the
+            // narrow one — any unique key over a subset of (user_id, plan_id,
+            // day), whatever it is called.
+            if ($hasWide) {
+                foreach ($indexes as $name => $spec) {
+                    if (
+                        $name === 'PRIMARY'
+                        || !$spec['unique']
+                        || array_diff($spec['columns'], $narrowColumns) !== []
+                    ) {
+                        continue;
+                    }
+
+                    $db->setQuery(
+                        'ALTER TABLE ' . $db->quoteName($table)
+                        . ' DROP INDEX ' . $db->quoteName($name)
+                    )->execute();
+
+                    unset($indexes[$name]);
+                    $repaired = true;
+                }
+            }
+
+            // The shipped schema keeps a plain (user_id, plan_id, day) index for
+            // the per-day lookups; dropping the narrow unique above takes it
+            // with it on an affected site.
+            if ($hasWide && !isset($indexes['idx_user_plan_day'])) {
+                $db->setQuery(
+                    'ALTER TABLE ' . $db->quoteName($table)
+                    . ' ADD KEY ' . $db->quoteName('idx_user_plan_day')
+                    . ' (' . implode(', ', $db->quoteName($narrowColumns)) . ')'
+                )->execute();
+            }
+
+            if ($repaired) {
+                // Worth saying out loud: it explains why days completed before
+                // the repair can still show as partially read. Those days hold
+                // the one row the old key allowed, and which passage it records
+                // is whichever the reader ticked first — so the missing rows
+                // cannot be backfilled without inventing progress.
+                Factory::getApplication()->enqueueMessage(
+                    'CWM LivingWord: repaired the reading-progress unique key, which had been limiting'
+                    . ' this site to one passage per day. Days completed before now may still show as'
+                    . ' partially read — re-ticking their passages records them properly.',
+                    'message'
+                );
+            }
+        } catch (\Throwable $e) {
+            // Say so rather than fail the update: the site keeps working, and
+            // the reader loses per-passage ticks, not the component.
+            Factory::getApplication()->enqueueMessage(
+                'CWM LivingWord: could not repair the reading-progress unique key — ' . $e->getMessage(),
                 'warning'
             );
         }

--- a/site/src/Controller/CwmcompleteController.php
+++ b/site/src/Controller/CwmcompleteController.php
@@ -17,6 +17,7 @@ use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
 
@@ -80,10 +81,23 @@ class CwmcompleteController extends BaseController
         $passageCount = CwmprogressHelper::countPassages($reading->reading);
 
         // Mark all passages as complete (idempotent)
-        for ($i = 0; $i < $passageCount; $i++) {
-            if (!CwmprogressHelper::isPassageCompleted($db, $userId, $planId, $currentDay, $i)) {
-                CwmprogressHelper::markPassageComplete($db, $userId, $planId, $currentDay, $i);
+        try {
+            for ($i = 0; $i < $passageCount; $i++) {
+                if (!CwmprogressHelper::isPassageCompleted($db, $userId, $planId, $currentDay, $i)) {
+                    CwmprogressHelper::markPassageComplete($db, $userId, $planId, $currentDay, $i);
+                }
             }
+        } catch (\RuntimeException $e) {
+            // The reading was not recorded, so the landing page must not say it
+            // was — this is the one-click link from the daily email, and its
+            // whole job is to be trustworthy about that.
+            Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
+            Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+
+            $app->setUserState('com_livingword.complete.success', false);
+            $this->setRedirect(Route::_('index.php?option=com_livingword&view=cwmcomplete', false));
+
+            return;
         }
 
         // Update streak

--- a/site/src/Controller/CwmcompleteController.php
+++ b/site/src/Controller/CwmcompleteController.php
@@ -17,7 +17,6 @@ use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use CWM\Component\Livingword\Site\Helper\CwmreadingHelper;
 use CWM\Component\Livingword\Site\Helper\CwmuserHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
 
@@ -91,8 +90,7 @@ class CwmcompleteController extends BaseController
             // The reading was not recorded, so the landing page must not say it
             // was — this is the one-click link from the daily email, and its
             // whole job is to be trustworthy about that.
-            Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
-            Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+            CwmprogressHelper::logFailure($e);
 
             $app->setUserState('com_livingword.complete.success', false);
             $this->setRedirect(Route::_('index.php?option=com_livingword&view=cwmcomplete', false));

--- a/site/src/Controller/CwmprogressController.php
+++ b/site/src/Controller/CwmprogressController.php
@@ -16,7 +16,6 @@ namespace CWM\Component\Livingword\Site\Controller;
 
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
@@ -90,12 +89,8 @@ class CwmprogressController extends BaseController
                 // A write the database refused. Answering with an error leaves
                 // the button in its old state, which is the truth; the previous
                 // behaviour was to report the tick as saved and drop it. The
-                // cause goes to the log rather than to the browser — with the
-                // logger registered explicitly, since Log discards a category
-                // no logger claims and a discarded record is the failure mode
-                // this whole change is about.
-                Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
-                Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+                // cause goes to the log rather than to the browser.
+                CwmprogressHelper::logFailure($e);
 
                 $app->sendHeaders();
                 echo new JsonResponse(null, 'Could not save your progress', true);
@@ -117,8 +112,7 @@ class CwmprogressController extends BaseController
         try {
             $completed = CwmprogressHelper::toggleComplete($db, $userId, $planId, $day, max($passageCount, 1));
         } catch (\RuntimeException $e) {
-            Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
-            Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+            CwmprogressHelper::logFailure($e);
 
             $app->sendHeaders();
             echo new JsonResponse(null, 'Could not save your progress', true);

--- a/site/src/Controller/CwmprogressController.php
+++ b/site/src/Controller/CwmprogressController.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Livingword\Site\Controller;
 
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
@@ -76,14 +77,30 @@ class CwmprogressController extends BaseController
 
         if ($passageIndex >= 0) {
             // Passage-level toggle
-            $result = CwmprogressHelper::togglePassage(
-                $db,
-                $userId,
-                $planId,
-                $day,
-                $passageIndex,
-                max($passageCount, 1)
-            );
+            try {
+                $result = CwmprogressHelper::togglePassage(
+                    $db,
+                    $userId,
+                    $planId,
+                    $day,
+                    $passageIndex,
+                    max($passageCount, 1)
+                );
+            } catch (\RuntimeException $e) {
+                // A write the database refused. Answering with an error leaves
+                // the button in its old state, which is the truth; the previous
+                // behaviour was to report the tick as saved and drop it. The
+                // cause goes to the log rather than to the browser — with the
+                // logger registered explicitly, since Log discards a category
+                // no logger claims and a discarded record is the failure mode
+                // this whole change is about.
+                Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
+                Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+
+                $app->sendHeaders();
+                echo new JsonResponse(null, 'Could not save your progress', true);
+                $app->close();
+            }
 
             $app->sendHeaders();
             echo new JsonResponse([
@@ -97,7 +114,16 @@ class CwmprogressController extends BaseController
         }
 
         // Day-level toggle (mark all passages at once)
-        $completed = CwmprogressHelper::toggleComplete($db, $userId, $planId, $day, max($passageCount, 1));
+        try {
+            $completed = CwmprogressHelper::toggleComplete($db, $userId, $planId, $day, max($passageCount, 1));
+        } catch (\RuntimeException $e) {
+            Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
+            Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+
+            $app->sendHeaders();
+            echo new JsonResponse(null, 'Could not save your progress', true);
+            $app->close();
+        }
 
         $app->sendHeaders();
         echo new JsonResponse([

--- a/site/src/Helper/CwmprogressHelper.php
+++ b/site/src/Helper/CwmprogressHelper.php
@@ -97,6 +97,13 @@ class CwmprogressHelper
     /**
      * Mark a specific passage as complete.
      *
+     * Re-marking a passage is a no-op, so the unique-constraint violation that
+     * produces is swallowed. Only that one: the check is whether the row is
+     * there afterwards, not which error code came back. A site carrying the
+     * pre-#7 narrow unique key raises the same violation for a *different* row
+     * — passage 2 colliding with passage 1 on (user_id, plan_id, day) — and
+     * swallowing that lost the write while reporting success (#143).
+     *
      * @param   DatabaseInterface  $db            Database instance
      * @param   int                $userId        Joomla user ID
      * @param   int                $planId        Plan ID
@@ -104,6 +111,8 @@ class CwmprogressHelper
      * @param   int                $passageIndex  0-based passage index
      *
      * @return  void
+     *
+     * @throws  \RuntimeException  When the passage could not be recorded.
      *
      * @since   5.5.0
      */
@@ -123,8 +132,23 @@ class CwmprogressHelper
 
         try {
             $db->insertObject('#__livingword_progress', $record);
-        } catch (\RuntimeException) {
-            // Already exists (unique constraint) — ignore
+        } catch (\RuntimeException $e) {
+            if (self::isPassageCompleted($db, $userId, $planId, $day, $passageIndex)) {
+                // Already marked — the insert was redundant, not lost.
+                return;
+            }
+
+            throw new \RuntimeException(
+                \sprintf(
+                    'Could not record passage %d of day %d for plan %d: %s',
+                    $passageIndex,
+                    $day,
+                    $planId,
+                    $e->getMessage()
+                ),
+                (int) $e->getCode(),
+                $e
+            );
         }
     }
 

--- a/site/src/Helper/CwmprogressHelper.php
+++ b/site/src/Helper/CwmprogressHelper.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Livingword\Site\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Log\Log;
 use Joomla\Database\DatabaseInterface;
 
 /**
@@ -149,6 +150,31 @@ class CwmprogressHelper
                 (int) $e->getCode(),
                 $e
             );
+        }
+    }
+
+    /**
+     * Record a progress write the database refused.
+     *
+     * The category is registered on the spot because Log drops one no logger
+     * has claimed, and a dropped record is the failure mode this path exists to
+     * end. Wrapped in turn because the file logger throws when it cannot open
+     * its file, and callers reach this from inside their own catch — a log that
+     * cannot be written must not swallow the response that reports the failure.
+     *
+     * @param   \Throwable  $e  The failure to record
+     *
+     * @return  void
+     *
+     * @since   5.7.0
+     */
+    public static function logFailure(\Throwable $e): void
+    {
+        try {
+            Log::addLogger(['text_file' => 'com_livingword.php'], Log::ERROR, ['com_livingword']);
+            Log::add($e->getMessage(), Log::ERROR, 'com_livingword');
+        } catch (\Throwable) {
+            // Nothing further to do — the caller still reports the failure.
         }
     }
 

--- a/tests/unit/Site/Helper/CwmprogressHelperTest.php
+++ b/tests/unit/Site/Helper/CwmprogressHelperTest.php
@@ -9,6 +9,8 @@
 namespace CWM\Component\Livingword\Tests\Site\Helper;
 
 use CWM\Component\Livingword\Site\Helper\CwmprogressHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\QueryInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -112,5 +114,63 @@ class CwmprogressHelperTest extends TestCase
             'three passages' => ['Genesis 1; Psalm 23; John 3:16', 3],
             'five passages'  => ['Gen 1; Gen 2; Gen 3; Gen 4; Gen 5', 5],
         ];
+    }
+
+    // ── markPassageComplete (#143) ──
+
+    public function testMarkPassageCompleteIsQuietWhenTheRowIsAlreadyThere(): void
+    {
+        // Re-marking a passage: the insert is refused, the row is present, and
+        // there is nothing to report.
+        $db = $this->mockDatabase(new \RuntimeException('Duplicate entry'), rowPresent: true);
+
+        CwmprogressHelper::markPassageComplete($db, 42, 7, 3, 1);
+    }
+
+    public function testMarkPassageCompleteThrowsWhenTheRowWasNotStored(): void
+    {
+        // The pre-#7 narrow unique key: passage 1 collides with passage 0 on
+        // (user_id, plan_id, day), so the same violation means a lost write.
+        $db = $this->mockDatabase(new \RuntimeException('Duplicate entry'), rowPresent: false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not record passage 1 of day 3 for plan 7');
+
+        CwmprogressHelper::markPassageComplete($db, 42, 7, 3, 1);
+    }
+
+    public function testMarkPassageCompleteThrowsOnANonDuplicateFailure(): void
+    {
+        // A missing passage_index column raises "unknown column", not a
+        // constraint violation — swallowed just as silently before #143.
+        $db = $this->mockDatabase(new \RuntimeException('Unknown column'), rowPresent: false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unknown column');
+
+        CwmprogressHelper::markPassageComplete($db, 42, 7, 3, 0);
+    }
+
+    /**
+     * A database whose insert fails and whose follow-up count says whether the
+     * row exists — the only two things markPassageComplete() consults.
+     */
+    private function mockDatabase(\RuntimeException $insertFailure, bool $rowPresent): DatabaseInterface
+    {
+        $query = $this->createStub(QueryInterface::class);
+        $query->method('select')->willReturnSelf();
+        $query->method('from')->willReturnSelf();
+        $query->method('where')->willReturnSelf();
+
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getQuery')->willReturn($query);
+        $db->method('quoteName')->willReturnArgument(0);
+        $db->method('setQuery')->willReturnSelf();
+        $db->method('loadResult')->willReturn($rowPresent ? '1' : '0');
+        $db->expects($this->once())
+            ->method('insertObject')
+            ->willThrowException($insertFailure);
+
+        return $db;
     }
 }


### PR DESCRIPTION
Closes #143.

## The defect

Per-passage completion (#7) added `passage_index` to `#__livingword_progress` and widened the unique key to cover it — in `admin/sql/install.mysql.utf8.sql` only. `CREATE TABLE IF NOT EXISTS` does not alter an existing table, so every site that installed before #7 and upgraded still carries `UNIQUE (user_id, plan_id, day)`, which holds one passage per day. Passage 2 is refused, the request returns 200, and the day renders as permanently partly read while streaks report it complete.

Confirmed here before touching anything — j6-dev, carried forward across #7:

```
idx_user_plan_day   UNIQUE  (user_id, plan_id, day)   <-- narrow
```

against j5-dev, j6-test and j70-dev (fresh installs), all of which had the wide key.

## The fix

**`script.php::ensureProgressPassageKey()`** — runs from postflight on install and update, alongside the two `ensure*` repairs already there. In PHP for the reason `ensureActionTokenIndex()` documents: Joomla runs update SQL only when it is newer than the recorded `#__schemas` version, and MySQL has no `DROP`/`ADD INDEX IF EXISTS`, so a plain ALTER would fail on every site that is already correct.

- Matches the narrow key **on shape, not on name** — a hand-patched site may carry it under a different one.
- Adds the wide key **before** dropping the narrow one, so a failed ALTER leaves the table with the protection it had. Widening a unique key can never fail on existing data.
- Restores the plain three-column index that the drop takes with it.
- Adds `passage_index` itself first: an upgraded site can be missing the column too, and `insertObject()` then failed on "unknown column" into the same silent catch.

`admin/sql/updates/mysql/5.7.0.sql` carries no DDL and says why, matching the 5.6.0 file.

**`CwmprogressHelper::markPassageComplete()`** — no longer swallows every `RuntimeException`. It re-checks the row and rethrows when the write was genuinely lost. Driver-agnostic by design: the test is whether the row is there afterwards, not which error code came back. `CwmprogressController` answers `success: false` (the JS already handles that and leaves the button in its true state) and `CwmcompleteController` sends the email landing page down its existing failure path rather than claiming the reading was recorded.

**`build/verify-migrations.php`** — covers `livingword_progress`, which it never did, and index expectations can now assert uniqueness and column order. Existence alone would have passed a site carrying both keys with the three-column one still UNIQUE — which still blocks passage 2. Its config reader also moved to a child process: a run with two `role=test` installs used to fatal on the duplicate `JConfig` class declaration.

## Not backfilling historical rows

A multi-passage day completed on an affected site holds exactly one row, and its `passage_index` is whichever passage the reader ticked first — a single row does not mean the day was finished. Filling in the rest would invent progress, so those days keep showing as partly read until re-ticked. The postflight message says so. Happy to change this if you'd rather it backfill.

## Verified

| step | result |
|---|---|
| j6-test forced into the pre-#7 state, gate run | FAIL — missing `idx_user_plan_day_passage`, and `idx_user_plan_day` is UNIQUE |
| built package installed over it (real update path) | postflight reported the repair; key restored to the shipped shape |
| gate re-run | 24 assertions, pass |
| package installed a second time | silent no-op, no repair message, no error |
| `composer seed -- --install=j6-test` | 632 rows written, **0 rejected** (was 42 rejected on the narrow key) |

`composer check` green: syntax, php-cs-fixer, 69 tests / 1769 assertions. Three new unit tests cover the redundant insert, the lost write, and a non-duplicate failure.

To put a dev install back into the broken state for testing:

```sql
ALTER TABLE `x_livingword_progress`
  DROP INDEX `idx_user_plan_day_passage`, DROP INDEX `idx_user_plan_day`,
  ADD UNIQUE KEY `idx_user_plan_day` (`user_id`, `plan_id`, `day`);
```

(j6-dev has been repaired; its 591 existing rows were kept.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)