### PR TITLE
chore(dev): make the admin manifest symlink relative

### DIFF
--- a/admin/livingword.xml
+++ b/admin/livingword.xml
@@ -1,1 +1,1 @@
-/Volumes/BCCExt_APFS_Extreme_Pro/GitHub/CWMLivingWord/livingword.xml
+../livingword.xml

--- a/tests/unit/ManifestNamespaceTest.php
+++ b/tests/unit/ManifestNamespaceTest.php
@@ -91,8 +91,13 @@ class ManifestNamespaceTest extends TestCase
         $found = [];
 
         foreach ([...glob(self::ROOT . '/*.xml'), ...glob(self::ROOT . '/*/*.xml')] as $file) {
-            // A manifest that is a symlink is not a source of truth.
-            // admin/livingword.xml is one, pointing at the root manifest.
+            // A manifest that is a symlink is not a manifest of its own.
+            // admin/livingword.xml points at the root one: cwm-link symlinks
+            // administrator/components/com_livingword to this repo's admin/,
+            // and Joomla's Discover looks for the manifest inside that folder,
+            // where a package install would have put a copy. It is the same
+            // extension, so it belongs to the root manifest's entry, not to a
+            // fifth one the build config is missing.
             if (is_link($file) || !str_contains((string) file_get_contents($file), '<namespace')) {
                 continue;
             }


### PR DESCRIPTION
Follow-up to #146. I flagged `admin/livingword.xml` as a deletion candidate there and was wrong about it being dead — it has a job, and Brent named it: the symlink is what makes **dev sites** work.

`cwm-link` symlinks `administrator/components/com_livingword` → this repo's `admin/`, and Joomla's Extension Manager → Discover looks for the manifest *inside* that folder, which is where a package install puts a copy of its own. Verified on j6-dev:

```
administrator/components/com_livingword -> …/CWMLivingWord/admin
administrator/components/com_livingword/livingword.xml -> …/CWMLivingWord/livingword.xml
```

Deleting it would have broken the Discover step that `CLAUDE.md` documents as the one-time setup after `composer verify`.

## What was actually wrong

The symlink target was **absolute** — `/Volumes/BCCExt_APFS_Extreme_Pro/GitHub/CWMLivingWord/livingword.xml` — so it resolved on one machine and dangled in every other clone and in CI. Now it is `../livingword.xml`, which does the same job from any checkout. Confirmed it still resolves both directly and through the dev site's symlinked component directory.

Also gives the manifest spec's symlink guard its real reason: this file is the root manifest seen from the admin folder, not a fifth extension missing from `cwm-build.config.json`.

`composer check` green: 84 tests, 2057 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)