### PR TITLE
fix(install): stop LivingWord from uninstalling Proclaim's scripture stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,9 @@ jobs:
           - \`com_livingword\` $VERSION — LivingWord component (admin + site + media)
           - \`mod_livingword\` — Daily reading module
           - \`plg_task_livingword\` — Scheduled email delivery task plugin
-          - \`lib_cwmscripture\` v$SCRIPTURE — Bible provider library
-          - \`plg_content_scripturelinks\` v$SCRIPTURE — Scripture linking content plugin
+          - \`pkg_cwmscripture\` v$SCRIPTURE — Bible provider library, scripture linking
+            and scripture task plugins. Installed only if your site has an older
+            version; uninstalling LivingWord leaves it in place.
 
           ## Requirements
 

--- a/build/fetch_dependencies.php
+++ b/build/fetch_dependencies.php
@@ -3,10 +3,10 @@
 /**
  * LivingWord — fetch external build dependencies.
  *
- * Downloads the latest stable pkg_cwmscripture release from GitHub and
- * extracts the inner lib + plugin zips used by the LivingWord package build.
+ * Downloads the latest stable pkg_cwmscripture release from GitHub. The build
+ * bundles the package whole, not its three inner zips — see script.install.php.
  *
- * Fails hard on any network, API, or extraction error — offline builds are
+ * Fails hard on any network, API, or verification error — offline builds are
  * not supported because shipping a stale scripture library would silently
  * hide breakage against the latest API.
  */
@@ -20,8 +20,8 @@ const SCRIPTURE_INNER_ZIPS   = [
 ];
 
 /**
- * Fetch the latest stable pkg_cwmscripture release and extract its inner zips
- * into the given vendor directory.
+ * Fetch the latest stable pkg_cwmscripture release into the given vendor
+ * directory, verifying it carries the extensions LivingWord depends on.
  *
  * @param   string  $vendorDir  Absolute path where inner zips should land.
  * @param   bool    $verbose    Whether to echo progress.
@@ -67,12 +67,9 @@ function fetchScriptureDependencies(string $vendorDir, bool $verbose = false): a
     $pkgZipPath = $vendorDir . '/' . $assetName;
     ghDownload($assetUrl, $pkgZipPath);
 
-    // Extract the package zip to a temp dir, then move inner zips into vendor/.
-    $tempDir = $vendorDir . '/.tmp-' . bin2hex(random_bytes(4));
-
-    if (!mkdir($tempDir, 0755, true)) {
-        throw new \RuntimeException("Cannot create temp dir: $tempDir");
-    }
+    // Kept whole: unpacking here is what made the scripture extensions package
+    // children of LivingWord, so removing LivingWord uninstalled Proclaim's stack.
+    $canonical = $vendorDir . '/' . SCRIPTURE_PACKAGE_NAME . '.zip';
 
     try {
         $zip = new ZipArchive();
@@ -81,43 +78,32 @@ function fetchScriptureDependencies(string $vendorDir, bool $verbose = false): a
             throw new \RuntimeException("Cannot open downloaded package: $pkgZipPath");
         }
 
-        if (!$zip->extractTo($tempDir)) {
-            $zip->close();
-            throw new \RuntimeException("Cannot extract $pkgZipPath to $tempDir");
+        // Verified, not extracted — catch a release missing an extension here
+        // rather than on a site.
+        foreach (SCRIPTURE_INNER_ZIPS as $innerZip) {
+            if ($zip->locateName($innerZip) === false) {
+                $zip->close();
+
+                throw new \RuntimeException("Expected inner zip $innerZip not found in $assetName");
+            }
         }
 
         $zip->close();
 
-        $results = [];
-
-        foreach (SCRIPTURE_INNER_ZIPS as $innerZip) {
-            $source = $tempDir . '/' . $innerZip;
-
-            if (!file_exists($source)) {
-                throw new \RuntimeException("Expected inner zip $innerZip not found in $assetName");
-            }
-
-            $dest = $vendorDir . '/' . $innerZip;
-
-            if (file_exists($dest)) {
-                unlink($dest);
-            }
-
-            if (!rename($source, $dest)) {
-                throw new \RuntimeException("Failed to move $innerZip to vendor directory");
-            }
-
-            $results[$innerZip] = $dest;
-
-            if ($verbose) {
-                echo "  + $innerZip\n";
-            }
+        if (file_exists($canonical) && !unlink($canonical)) {
+            throw new \RuntimeException("Cannot replace $canonical");
         }
 
-        return ['version' => $version, 'zips' => $results];
-    } finally {
-        rrmdir($tempDir);
+        if (!rename($pkgZipPath, $canonical)) {
+            throw new \RuntimeException("Failed to move $assetName to vendor directory");
+        }
 
+        if ($verbose) {
+            echo '  + ' . SCRIPTURE_PACKAGE_NAME . '.zip (' . count(SCRIPTURE_INNER_ZIPS) . " extensions inside)\n";
+        }
+
+        return ['version' => $version, 'zips' => [SCRIPTURE_PACKAGE_NAME . '.zip' => $canonical]];
+    } finally {
         if (file_exists($pkgZipPath)) {
             unlink($pkgZipPath);
         }
@@ -253,34 +239,9 @@ function ghDownload(string $url, string $destination): void
     }
 }
 
-/**
- * Recursively remove a directory.
- */
-function rrmdir(string $dir): void
-{
-    if (!is_dir($dir)) {
-        return;
-    }
-
-    $items = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
-        RecursiveIteratorIterator::CHILD_FIRST
-    );
-
-    foreach ($items as $item) {
-        if ($item->isDir()) {
-            rmdir($item->getPathname());
-        } else {
-            unlink($item->getPathname());
-        }
-    }
-
-    rmdir($dir);
-}
-
 // CLI entry — fires only when invoked directly (php build/fetch_dependencies.php),
-// not when included via require_once. Writes the 3 scripture zips into build/vendor/
-// for cwm-package's `prebuilt` includes to pick up.
+// not when included via require_once. Writes build/vendor/pkg_cwmscripture.zip for
+// cwm-package's `prebuilt` include to pick up.
 if (PHP_SAPI === 'cli' && isset($_SERVER['SCRIPT_FILENAME']) && realpath($_SERVER['SCRIPT_FILENAME']) === __FILE__) {
     $vendorDir = __DIR__ . '/vendor';
     $verbose   = in_array('--verbose', $argv ?? [], true) || in_array('-v', $argv ?? [], true);

--- a/build/pkg_livingword.xml
+++ b/build/pkg_livingword.xml
@@ -13,31 +13,28 @@
 
     <changelogurl>https://raw.githubusercontent.com/Joomla-Bible-Study/CWMLivingWord/main/build/livingword-changelog.xml</changelogurl>
 
+    <!-- Installs the bundled pkg_cwmscripture; see the note on <files> below.
+         No <blockChildUninstall>: it would re-assert the ownership we're giving up. -->
+    <scriptfile>script.install.php</scriptfile>
+
     <!-- ARS update stream 6 (see cwm-build.config.json ars.updateStreamId).
-         The task=stream parameter is required — without it ARS falls back to
-         task=all and returns an <extensionset> category index instead of the
-         <updates> document Joomla's extension update adapter expects.
-         The trailing dummy=extension.xml is ignored by ARS; it exists so
-         proxies and caches that sniff the URL extension see an .xml file.
-         Matches pkg_proclaim.xml. -->
+         task=stream is required — without it ARS returns an <extensionset> index
+         instead of the <updates> document Joomla's update adapter expects. -->
     <updateservers>
         <server type="extension" name="CWM LivingWord Package">https://www.christianwebministries.org/index.php?option=com_ars&amp;view=update&amp;task=stream&amp;format=xml&amp;id=6&amp;dummy=extension.xml</server>
     </updateservers>
 
-    <!-- folder must match package.innerLayout in cwm-build.config.json, which
-         is "packages-prefix" — the inner zips are assembled under packages/.
-         Without it Joomla looks for them at the archive root, InstallerHelper::
-         unpack() returns false, and PackageAdapter aborts with "Unable to
-         install extension" after a "Trying to access array offset on false"
-         warning. Compare pkg_proclaim.xml (packages-prefix + folder) and
-         pkg_cwmscripture.xml (root layout + no folder). -->
+    <!-- folder must match package.innerLayout ("packages-prefix") in
+         cwm-build.config.json, or PackageAdapter can't find the inner zips.
+
+         The scripture stack is deliberately absent: removeExtensionFiles()
+         uninstalls every entry here by element, so declaring it made removing
+         LivingWord take a stack shared with Proclaim. packages/pkg_cwmscripture.zip
+         ships as an undeclared extra that script.install.php installs. -->
     <files folder="packages">
-        <file type="library" id="cwmscripture">lib_cwmscripture.zip</file>
         <file type="component" id="com_livingword">com_livingword.zip</file>
         <file type="module" client="site" id="mod_livingword">mod_livingword.zip</file>
         <file type="plugin" group="task" id="livingword">plg_task_livingword.zip</file>
         <file type="plugin" group="webservices" id="livingword">plg_webservices_livingword.zip</file>
-        <file type="plugin" group="task" id="cwmscripture">plg_task_cwmscripture.zip</file>
-        <file type="plugin" group="content" id="scripturelinks">plg_content_scripturelinks.zip</file>
     </files>
 </extension>

--- a/build/script.install.php
+++ b/build/script.install.php
@@ -1,0 +1,405 @@
+<?php
+
+/**
+ * Package installer script for pkg_livingword.
+ *
+ * Exists for one job: install the bundled scripture stack without declaring it
+ * as a package child. See installScriptureStack() for why that distinction
+ * matters.
+ *
+ * @package    LivingWord
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @since      __DEPLOY_VERSION__
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Installer\Installer;
+use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\CMS\Installer\InstallerHelper;
+use Joomla\CMS\Installer\InstallerScriptInterface;
+use Joomla\CMS\Log\Log;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+use Joomla\Filesystem\Folder;
+
+/**
+ * Returns an anonymous class implementing InstallerScriptInterface.
+ *
+ * Joomla 5+ expects the script file to return an InstallerScriptInterface
+ * instance directly (not define a named class).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+return new class () implements InstallerScriptInterface {
+    /**
+     * The scripture extensions, as #__extensions identifies them.
+     *
+     * @var    array<int, array{type: string, element: string, folder: string}>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const SCRIPTURE_EXTENSIONS = [
+        ['type' => 'library', 'element' => 'cwmscripture',   'folder' => ''],
+        ['type' => 'plugin',  'element' => 'scripturelinks', 'folder' => 'content'],
+        ['type' => 'plugin',  'element' => 'cwmscripture',   'folder' => 'task'],
+    ];
+
+    /**
+     * Install the bundled scripture stack, which is not a package child.
+     *
+     * pkg_cwmscripture ships inside this archive but pkg_livingword.xml does not
+     * declare it. PackageAdapter::removeExtensionFiles() uninstalls every entry
+     * in the installed manifest's <files> by element — package_id has no say —
+     * so declaring the scripture extensions, as 5.7.0 and earlier did, meant
+     * removing LivingWord took a stack Proclaim was still using.
+     *
+     * Runs in preflight because com_livingword's own postflight registers itself
+     * in the library's consumer registry, and registerScriptureConsumer() returns
+     * silently when ConsumerRegistry cannot be autoloaded. Installing later would
+     * leave LivingWord unregistered.
+     *
+     * Skips when an equal or newer pkg_cwmscripture is already installed, so a
+     * site carrying a current one — from Proclaim or standalone — is never
+     * downgraded.
+     *
+     * @param   InstallerAdapter  $adapter  The installer adapter
+     *
+     * @return  bool  False only when the stack is required and could not be installed
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function installScriptureStack(InstallerAdapter $adapter): bool
+    {
+        $zip = $adapter->getParent()->getPath('source') . '/packages/pkg_cwmscripture.zip';
+
+        if (!is_file($zip)) {
+            // A site can legitimately carry the stack from Proclaim or standalone.
+            if ($this->scriptureLibraryPresent()) {
+                return true;
+            }
+
+            Factory::getApplication()->enqueueMessage(
+                'The scripture package is missing from this LivingWord archive and no scripture '
+                . 'library is installed. Install pkg_cwmscripture first, then retry.',
+                'error'
+            );
+
+            return false;
+        }
+
+        try {
+            $bundled   = $this->manifestVersionInZip($zip);
+            $installed = $this->installedVersion('pkg_cwmscripture', 'package');
+
+            if ($installed !== null && $bundled !== null && version_compare($installed, $bundled, '>=')) {
+                Log::add(
+                    "pkg_livingword: pkg_cwmscripture {$installed} already installed (bundled {$bundled}).",
+                    Log::INFO,
+                    'com_livingword'
+                );
+
+                return true;
+            }
+
+            $package = InstallerHelper::unpack($zip, true);
+
+            if ($package === false) {
+                throw new \RuntimeException('could not unpack pkg_cwmscripture.zip');
+            }
+
+            $installer = new Installer();
+            $installer->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
+            $result = $installer->install($package['dir']);
+
+            // Only the unpacked copy. $zip lives in our own extracted source tree,
+            // which the parent installer cleans up.
+            if (is_dir($package['dir'])) {
+                Folder::delete($package['dir']);
+            }
+
+            if (!$result) {
+                throw new \RuntimeException('the installer reported a failure');
+            }
+
+            Log::add('pkg_livingword: installed the bundled scripture stack.', Log::INFO, 'com_livingword');
+
+            return true;
+        } catch (\Throwable $e) {
+            // A failed refresh is not worth blocking when a usable library is there.
+            if ($this->scriptureLibraryPresent()) {
+                Log::add(
+                    'pkg_livingword: could not refresh the scripture stack (' . $e->getMessage()
+                    . ') — continuing with the installed one.',
+                    Log::WARNING,
+                    'com_livingword'
+                );
+
+                return true;
+            }
+
+            Factory::getApplication()->enqueueMessage(
+                'LivingWord could not install the scripture library it depends on: ' . $e->getMessage(),
+                'error'
+            );
+
+            return false;
+        }
+    }
+
+    /**
+     * Repoint scripture extensions still recorded as children of this package.
+     *
+     * 5.7.0 and earlier installed them directly, stamping package_id with
+     * pkg_livingword's id. Dropping them from <files> stops the uninstall
+     * cascade, but the stale row still shows them as ours in the Extensions
+     * manager — so hand them to pkg_cwmscripture, or orphan them if it is
+     * somehow absent.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function releaseScriptureExtensions(): void
+    {
+        try {
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+            $ours = $this->extensionId('pkg_livingword', 'package');
+
+            if ($ours === null) {
+                return;
+            }
+
+            $owner = $this->extensionId('pkg_cwmscripture', 'package') ?? 0;
+
+            foreach (self::SCRIPTURE_EXTENSIONS as $extension) {
+                $query = $db->createQuery()
+                    ->update($db->quoteName('#__extensions'))
+                    ->set($db->quoteName('package_id') . ' = :owner')
+                    ->where($db->quoteName('type') . ' = :type')
+                    ->where($db->quoteName('element') . ' = :element')
+                    ->where($db->quoteName('folder') . ' = :folder')
+                    ->where($db->quoteName('package_id') . ' = :ours')
+                    ->bind(':owner', $owner, ParameterType::INTEGER)
+                    ->bind(':type', $extension['type'])
+                    ->bind(':element', $extension['element'])
+                    ->bind(':folder', $extension['folder'])
+                    ->bind(':ours', $ours, ParameterType::INTEGER);
+
+                $db->setQuery($query)->execute();
+            }
+        } catch (\Throwable $e) {
+            Log::add(
+                'pkg_livingword: could not release the scripture extensions (' . $e->getMessage() . ').',
+                Log::WARNING,
+                'com_livingword'
+            );
+        }
+    }
+
+    /**
+     * Whether a usable scripture library is present on disk.
+     *
+     * On disk rather than in #__extensions: preflight can run before the row
+     * exists, and the row can outlive the files.
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function scriptureLibraryPresent(): bool
+    {
+        return is_file(JPATH_LIBRARIES . '/cwmscripture/src/Helper/ScriptureHelper.php');
+    }
+
+    /**
+     * Extension id of an installed extension, or null when it is not installed.
+     *
+     * @param   string  $element  Extension element
+     * @param   string  $type     Extension type
+     *
+     * @return  int|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function extensionId(string $element, string $type): ?int
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery()
+            ->select($db->quoteName('extension_id'))
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('element') . ' = :element')
+            ->where($db->quoteName('type') . ' = :type')
+            ->bind(':element', $element)
+            ->bind(':type', $type);
+
+        $id = $db->setQuery($query)->loadResult();
+
+        return $id === null ? null : (int) $id;
+    }
+
+    /**
+     * Version of an installed extension, or null when it is not installed.
+     *
+     * @param   string  $element  Extension element
+     * @param   string  $type     Extension type
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function installedVersion(string $element, string $type): ?string
+    {
+        try {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->createQuery()
+                ->select($db->quoteName('manifest_cache'))
+                ->from($db->quoteName('#__extensions'))
+                ->where($db->quoteName('element') . ' = :element')
+                ->where($db->quoteName('type') . ' = :type')
+                ->bind(':element', $element)
+                ->bind(':type', $type);
+
+            $cache = $db->setQuery($query)->loadResult();
+
+            if (!$cache) {
+                return null;
+            }
+
+            $decoded = json_decode((string) $cache, true, 512, JSON_THROW_ON_ERROR);
+
+            return $decoded['version'] ?? null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Version declared by the manifest inside a package zip.
+     *
+     * @param   string  $zip  Absolute path to the zip
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function manifestVersionInZip(string $zip): ?string
+    {
+        $archive = new \ZipArchive();
+
+        if ($archive->open($zip) !== true) {
+            return null;
+        }
+
+        $version = null;
+
+        for ($i = 0; $i < $archive->numFiles; $i++) {
+            $name = $archive->getNameIndex($i);
+
+            // The package manifest sits at the archive root.
+            if ($name === false || substr_count($name, '/') > 0 || !str_ends_with($name, '.xml')) {
+                continue;
+            }
+
+            $xml = simplexml_load_string((string) $archive->getFromIndex($i));
+
+            if ($xml !== false && isset($xml->version)) {
+                $version = (string) $xml->version;
+
+                break;
+            }
+        }
+
+        $archive->close();
+
+        return $version;
+    }
+
+    /**
+     * Runs before install/update/uninstall.
+     *
+     * @param   string            $type     Install type
+     * @param   InstallerAdapter  $adapter  The installer adapter
+     *
+     * @return  bool  False aborts the install
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function preflight(string $type, InstallerAdapter $adapter): bool
+    {
+        if ($type === 'uninstall') {
+            return true;
+        }
+
+        return $this->installScriptureStack($adapter);
+    }
+
+    /**
+     * Runs on install.
+     *
+     * @param   InstallerAdapter  $adapter  The installer adapter
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function install(InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * Runs on update.
+     *
+     * @param   InstallerAdapter  $adapter  The installer adapter
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function update(InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * Runs on uninstall.
+     *
+     * Deliberately does not touch the scripture stack: it is shared with Proclaim
+     * and ScriptureLinks, and must survive — along with every downloaded
+     * translation — when LivingWord goes. That is the whole point of this file.
+     *
+     * @param   InstallerAdapter  $adapter  The installer adapter
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function uninstall(InstallerAdapter $adapter): bool
+    {
+        return true;
+    }
+
+    /**
+     * Runs after install/update/uninstall.
+     *
+     * @param   string            $type     Install type
+     * @param   InstallerAdapter  $adapter  The installer adapter
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function postflight(string $type, InstallerAdapter $adapter): bool
+    {
+        if ($type !== 'uninstall') {
+            $this->releaseScriptureExtensions();
+        }
+
+        return true;
+    }
+};

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
     "test": "phpunit",
     "test:unit": "phpunit --testsuite 'LivingWord Unit Tests'",
     "test:integration": "phpunit --testsuite 'LivingWord Integration Tests'",
-    "lint:syntax": "find admin site mod_livingword plg_task_livingword -name '*.php' -print0 | xargs -0 -n1 -P4 php -l",
+    "lint:syntax": "find admin site mod_livingword plg_task_livingword plg_webservices_livingword build/script.install.php -name '*.php' -print0 | xargs -0 -n1 -P4 php -l",
     "lint": "php-cs-fixer fix --dry-run --diff",
     "lint:fix": "php-cs-fixer fix",
     "lint:js": "npm run lint:js",

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -88,7 +88,7 @@
             "md"
         ],
         "preBuild": {
-            "_comment": "Runs once before cwm-package assembles the bundle: (1) wipes build/dist and build/vendor so stale zips from prior builds can't be picked up by outputGlob (regression seen during v5.0.1 release where the stale 5.0.0 zip got published alongside 5.0.1), (2) installs npm deps if missing, (3) bundles JS via rollup and minifies CSS via csso into media/com_livingword/{js,css}/, (4) fetches the latest pkg_cwmscripture release from GitHub and extracts its 3 inner zips into build/vendor/ for the prebuilt includes below.",
+            "_comment": "Runs once before cwm-package assembles the bundle: (1) wipes build/dist and build/vendor so stale zips from prior builds can't be picked up by outputGlob (regression seen during v5.0.1 release where the stale 5.0.0 zip got published alongside 5.0.1), (2) installs npm deps if missing, (3) bundles JS via rollup and minifies CSS via csso into media/com_livingword/{js,css}/, (4) fetches the latest pkg_cwmscripture release from GitHub into build/vendor/ for the prebuilt include below.",
             "mode": "run",
             "command": "rm -rf build/dist build/vendor && npm install --no-audit --no-fund && npm run build && php build/fetch_dependencies.php"
         },
@@ -98,8 +98,9 @@
         }
     },
     "package": {
-        "_comment": "Assembles pkg_livingword-{version}.zip with 6 inner zips: com_livingword (self), mod_livingword + plg_task_livingword (inline \u2014 built from this repo), and 3 scripture zips (prebuilt \u2014 fetched from GitHub by the preBuild hook).",
+        "_comment": "Assembles pkg_livingword-{version}.zip with 6 inner zips: com_livingword (self), mod_livingword + plg_task_livingword (inline \u2014 built from this repo), and pkg_cwmscripture (prebuilt \u2014 the whole scripture package, fetched from GitHub by the preBuild hook, installed by script.install.php rather than declared as a package child).",
         "manifest": "build/pkg_livingword.xml",
+        "installer": "build/script.install.php",
         "outputDir": "build/dist",
         "outputName": "pkg_livingword-{version}.zip",
         "innerLayout": "packages-prefix",
@@ -175,31 +176,21 @@
                 }
             },
             {
+                "_comment": "The whole scripture PACKAGE, not its three children. pkg_livingword.xml deliberately does not declare it, so removing LivingWord cannot uninstall a stack shared with Proclaim; build/script.install.php installs it in preflight instead.",
                 "type": "prebuilt",
-                "outputName": "lib_cwmscripture.zip",
-                "distGlob": "build/vendor/lib_cwmscripture.zip"
-            },
-            {
-                "type": "prebuilt",
-                "outputName": "plg_content_scripturelinks.zip",
-                "distGlob": "build/vendor/plg_content_scripturelinks.zip"
-            },
-            {
-                "type": "prebuilt",
-                "outputName": "plg_task_cwmscripture.zip",
-                "distGlob": "build/vendor/plg_task_cwmscripture.zip"
+                "outputName": "pkg_cwmscripture.zip",
+                "distGlob": "build/vendor/pkg_cwmscripture.zip"
             }
         ],
         "verify": {
             "expectedEntries": [
                 "pkg_livingword.xml",
+                "script.install.php",
                 "packages/com_livingword.zip",
                 "packages/mod_livingword.zip",
                 "packages/plg_task_livingword.zip",
                 "packages/plg_webservices_livingword.zip",
-                "packages/lib_cwmscripture.zip",
-                "packages/plg_content_scripturelinks.zip",
-                "packages/plg_task_cwmscripture.zip"
+                "packages/pkg_cwmscripture.zip"
             ]
         }
     },

--- a/tests/unit/PackageManifestTest.php
+++ b/tests/unit/PackageManifestTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * @package    Livingword.Tests
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Livingword\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What pkg_livingword.xml may and may not claim ownership of.
+ *
+ * PackageAdapter::removeExtensionFiles() reads the installed manifest and
+ * uninstalls every <file> in it by element — package_id has no say. Up to 5.7.0
+ * that list named lib_cwmscripture, plg_content_scripturelinks and
+ * plg_task_cwmscripture, so removing LivingWord took a scripture stack Proclaim
+ * was still using, and every downloaded translation with it.
+ *
+ * The fix is a package that ships pkg_cwmscripture.zip as an undeclared extra
+ * and installs it from build/script.install.php. Three things have to stay true
+ * for that to keep working, and each is one edit away from silently reverting.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PackageManifestTest extends TestCase
+{
+    private const ROOT = __DIR__ . '/../..';
+
+    private const MANIFEST = 'build/pkg_livingword.xml';
+
+    /**
+     * Elements that belong to the shared scripture stack, as <file id> spells them.
+     */
+    private const SCRIPTURE_IDS = ['cwmscripture', 'scripturelinks'];
+
+    /**
+     * The manifest declares nothing from the scripture stack.
+     *
+     * The regression itself. Re-adding a <file> for any of them restores the
+     * uninstall cascade — nothing else in the build or the test suite notices.
+     */
+    public function testTheManifestClaimsNoScriptureExtension(): void
+    {
+        foreach ($this->declaredFiles() as $file => $id) {
+            $this->assertNotContains(
+                $id,
+                self::SCRIPTURE_IDS,
+                self::MANIFEST . ' declares ' . $file . '. PackageAdapter uninstalls it by element when'
+                . ' LivingWord is removed, taking a stack shared with Proclaim.'
+            );
+        }
+    }
+
+    /**
+     * The scriptfile is declared, and it is a file that exists.
+     *
+     * Without it the bundled pkg_cwmscripture.zip is inert: it rides in the
+     * archive that nothing reads, and a clean install comes up with no scripture
+     * library at all.
+     */
+    public function testTheManifestRunsTheInstallerThatMakesUpForThat(): void
+    {
+        $xml = simplexml_load_file(self::ROOT . '/' . self::MANIFEST);
+
+        $this->assertNotFalse($xml, self::MANIFEST . ' is not readable XML.');
+        $this->assertTrue(
+            isset($xml->scriptfile),
+            self::MANIFEST . ' declares no <scriptfile>, so nothing installs the bundled scripture package.'
+        );
+
+        $scriptfile = (string) $xml->scriptfile;
+        $configured = $this->buildConfig()['package']['installer'] ?? null;
+
+        $this->assertSame(
+            'build/' . $scriptfile,
+            $configured,
+            'cwm-build.config.json package.installer must point at the manifest\'s <scriptfile>,'
+            . ' or the build ships a manifest naming a script that is not in the archive.'
+        );
+
+        $this->assertFileExists(self::ROOT . '/' . $configured);
+    }
+
+    /**
+     * No <blockChildUninstall>.
+     *
+     * It makes Joomla refuse to uninstall any extension whose package_id points
+     * at us — and on a site upgraded from 5.7.0 the scripture extensions still
+     * carry that stale package_id until postflight clears it. Setting it would
+     * re-assert exactly the ownership this package gave up.
+     */
+    public function testTheManifestDoesNotBlockChildUninstalls(): void
+    {
+        $xml = simplexml_load_file(self::ROOT . '/' . self::MANIFEST);
+
+        $this->assertFalse(
+            isset($xml->blockChildUninstall),
+            self::MANIFEST . ' sets <blockChildUninstall>, which re-claims extensions this package'
+            . ' deliberately no longer owns.'
+        );
+    }
+
+    /**
+     * The build's expected entries are the manifest's children plus the extra.
+     *
+     * The one that earns its keep: manifest and build config drift apart
+     * silently, and the failure mode is a package whose scripture zip is simply
+     * missing — which the installer then reports as an error on a clean site,
+     * long after the build passed.
+     */
+    public function testTheBuildShipsExactlyTheDeclaredChildrenPlusTheScripturePackage(): void
+    {
+        $config   = $this->buildConfig();
+        $expected = $config['package']['verify']['expectedEntries'] ?? [];
+
+        $this->assertNotEmpty($expected, 'cwm-build.config.json declares no expectedEntries.');
+
+        $wanted = [
+            basename(self::MANIFEST),
+            basename((string) $config['package']['installer']),
+            'packages/pkg_cwmscripture.zip',
+        ];
+
+        foreach (array_keys($this->declaredFiles()) as $file) {
+            $wanted[] = 'packages/' . $file;
+        }
+
+        sort($wanted);
+        sort($expected);
+
+        $this->assertSame(
+            $wanted,
+            $expected,
+            'The package manifest and cwm-build.config.json disagree about what the archive holds.'
+        );
+    }
+
+    /**
+     * Every include the build assembles is one the archive is expected to hold.
+     *
+     * Guards the assertion above from the other side: an include added to the
+     * config but left out of expectedEntries would ship unverified.
+     */
+    public function testEveryBuildIncludeIsAnExpectedEntry(): void
+    {
+        $config   = $this->buildConfig();
+        $expected = $config['package']['verify']['expectedEntries'] ?? [];
+
+        foreach ($config['package']['includes'] ?? [] as $include) {
+            $this->assertContains(
+                'packages/' . $include['outputName'],
+                $expected,
+                $include['outputName'] . ' is built but not listed in expectedEntries.'
+            );
+        }
+    }
+
+    /**
+     * Inner zip filename => the extension element the <file> claims.
+     *
+     * @return  array<string, string>
+     */
+    private function declaredFiles(): array
+    {
+        $xml = simplexml_load_file(self::ROOT . '/' . self::MANIFEST);
+
+        $this->assertNotFalse($xml, self::MANIFEST . ' is not readable XML.');
+
+        $files = [];
+
+        foreach ($xml->files->children() as $child) {
+            $files[(string) $child] = (string) $child->attributes()->id;
+        }
+
+        $this->assertNotEmpty($files, self::MANIFEST . ' declares no <file> entries.');
+
+        return $files;
+    }
+
+    /**
+     * @return  array<string, mixed>
+     */
+    private function buildConfig(): array
+    {
+        return json_decode((string) file_get_contents(self::ROOT . '/cwm-build.config.json'), true);
+    }
+}


### PR DESCRIPTION
## The bug

`build/pkg_livingword.xml` declared `lib_cwmscripture`, `plg_content_scripturelinks` and `plg_task_cwmscripture` as package children.

`PackageAdapter::removeExtensionFiles()` reads the *installed* manifest from `administrator/manifests/packages/` and resolves each declared `<file>` through `_getExtensionId($type, $element, $client, $group)` — **by element**. `package_id` never enters into it and never could. So removing LivingWord from a site that also runs Proclaim took the shared scripture stack with it, along with every downloaded translation.

## The fix

The package now ships `pkg_cwmscripture` **whole**, as an undeclared extra in the archive, and installs it from a package scriptfile.

| File | Change |
|---|---|
| `build/pkg_livingword.xml` | Scripture children removed; `<scriptfile>` added |
| `build/script.install.php` | **New.** Installs the bundled scripture package |
| `build/fetch_dependencies.php` | Verifies the release's three extensions instead of unpacking it |
| `cwm-build.config.json` | One `prebuilt` include for the whole package; `package.installer` wired |
| `tests/unit/PackageManifestTest.php` | **New.** Regression guard, 5 tests |
| `composer.json` | `lint:syntax` covers the installer and the webservices plugin |
| `.github/workflows/release.yml` | Release notes reworded |

### Design notes

**Preflight, not postflight.** `com_livingword`'s own postflight registers the component in the library's consumer registry, and `registerScriptureConsumer()` returns silently when `ConsumerRegistry` cannot be autoloaded. Installing the stack later would leave LivingWord unregistered — losing exactly the guard that keeps the shared tables alive when another consumer is removed. `InstallerAdapter::install()` runs `preflight` before `copyBaseFiles()`, so the library is on disk in time.

**No `<blockChildUninstall>`.** `InstallerAdapter::canUninstallPackageChild()` makes Joomla refuse to uninstall any extension whose `package_id` points at us. On a site upgraded from 5.7.0 the scripture extensions still carry that stale `package_id`, so setting it would re-assert the ownership this PR gives up. The postflight repoints those rows to `pkg_cwmscripture` instead.

**Never downgrades.** The install is skipped when an equal-or-newer `pkg_cwmscripture` is already present, so a site carrying a current one — from Proclaim, or standalone — is left alone.

**Not unpacking is the point.** Unpacking the release to bundle its three inner zips individually is precisely what made them package children. `fetch_dependencies.php` still verifies all three are in the release, so a broken upstream release fails at build time rather than on a site.

**Upgrade path.** `PackageAdapter::finaliseInstall()` runs on both the install and update routes and copies the manifest with overwrite — so a 5.7.0 site's stale filelist is replaced, and the cascade is gone on exactly the installs that have the bug.

## Testing

`composer check` passes (89 tests, 2077 assertions). `composer build` produces the 7-entry archive and self-verifies. `PackageManifestTest` was negative-tested: re-adding a scripture `<file>` fails 2 assertions.

Exercised end to end against **j6-test** (real, non-symlinked Joomla 6 install running Proclaim + `pkg_cwmscripture` 1.2.10):

| Scenario | Result |
|---|---|
| Install over existing `pkg_cwmscripture` 1.2.10 | Skip fired — scripture files untouched (mtime unchanged), no downgrade |
| **Uninstall LivingWord** | All four scripture extensions, files, media and tables survived |
| Install with an older version recorded | Stack installed, and `com_livingword` landed in the consumer registry — confirms preflight ordering |
| `package_id` stale, pointing at `pkg_livingword` | Postflight repointed all three rows to `pkg_cwmscripture`, library row included |

🤖 Generated with [Claude Code](https://claude.com/claude-code)