### PR TITLE
chore(deps): update cwm/build-tools to v1.23.2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,8 +42,14 @@ on:
       - 'build/test-install.sh'
       - 'build/test-upgrade.sh'
       - 'build/test-release.sh'
-      - 'build/reset-testsite.php'
       - 'build/verify-migrations.php'
+      # The harness resets the site through cwm-reset-testsite and resolves its
+      # upgrade baseline through cwm-baseline, both of which live in
+      # cwm/build-tools. A version bump replaces that code wholesale, so the
+      # lock belongs here or the job never sees the tooling it runs on.
+      # (build/reset-testsite.php was listed until it was deleted in favour of
+      # the shared command; the entry outlived the file.)
+      - 'composer.lock'
       - 'playwright.config.js'
       - 'cwm-build.config.json'
       - '.github/workflows/e2e.yml'

--- a/composer.lock
+++ b/composer.lock
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.23.1",
+            "version": "v1.23.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "8040210504b6a5fe6986e09c44ea7a7b5776e8b7"
+                "reference": "5608c46338bae6ddd42994151a87c774f923fa55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/8040210504b6a5fe6986e09c44ea7a7b5776e8b7",
-                "reference": "8040210504b6a5fe6986e09c44ea7a7b5776e8b7",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/5608c46338bae6ddd42994151a87c774f923fa55",
+                "reference": "5608c46338bae6ddd42994151a87c774f923fa55",
                 "shasum": ""
             },
             "require": {
@@ -407,10 +407,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.23.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.23.2",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-17T18:47:43+00:00"
+            "time": "2026-08-17T21:52:18+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Picks up [v1.23.2](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.23.2). Only `cwm/build-tools` moves in the lock.

**The one that matters most here is `cwm-baseline`.** It reported a `gh` failure — auth, network, a typo'd repo — as exit **3**, "no usable baseline", which callers are told to read as *not applicable, not a failure*.

`build/test-upgrade.sh` resolves its baseline through that command. So an auth or network failure would have read as "nothing to upgrade from" and the upgrade phase would have stood down silently — which is precisely the failure this project reported upstream as #101 in the first place, reappearing inside the tool written to fix it. Error and not-applicable are now distinct.

Also included:

- **`cwm-ars-publish`** verifies the GitHub release through authenticated `gh` instead of a bare `curl`, which 404s on a private repo
- **1Password failures name their cause** rather than collapsing into `Could not retrieve API token`
- **`cwm-reset-testsite`** matches table prefixes literally instead of treating `_` as a LIKE wildcard — relevant because this project's `testSite.reset` declares `livingword_`, and the scripture group declares `bsms_bible`

Verified the fixes are present in the vendored tree rather than trusting the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
