### PR TITLE
chore(ci): add lint-workflows to the check chain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
     "test": "phpunit",
     "test:unit": "phpunit --testsuite 'LivingWord Unit Tests'",
     "test:integration": "phpunit --testsuite 'LivingWord Integration Tests'",
+    "lint-workflows": "cwm-lint-workflows",
     "lint:syntax": "find admin site mod_livingword plg_task_livingword plg_webservices_livingword build/script.install.php -name '*.php' -print0 | xargs -0 -n1 -P4 php -l",
     "lint": "php-cs-fixer fix --dry-run --diff",
     "lint:fix": "php-cs-fixer fix",
@@ -111,7 +112,7 @@
     "build:css": "npm run build:css",
     "check": [
       "@lint:syntax",
-      "@lint",
+      "@lint-workflows", "@lint",
       "@test"
     ],
     "install-zip": "cwm-install-zip",

--- a/composer.lock
+++ b/composer.lock
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.23.2",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "5608c46338bae6ddd42994151a87c774f923fa55"
+                "reference": "10669fb366d601e4e6e8d12f8c3f95613ddefe56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/5608c46338bae6ddd42994151a87c774f923fa55",
-                "reference": "5608c46338bae6ddd42994151a87c774f923fa55",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/10669fb366d601e4e6e8d12f8c3f95613ddefe56",
+                "reference": "10669fb366d601e4e6e8d12f8c3f95613ddefe56",
                 "shasum": ""
             },
             "require": {
@@ -341,6 +341,7 @@
                 "bin/cwm-baseline",
                 "bin/cwm-lint-queries",
                 "bin/cwm-lint-comments",
+                "bin/cwm-lint-workflows",
                 "bin/cwm-reset-testsite",
                 "bin/cwm-verify-update-stream"
             ],
@@ -407,10 +408,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.23.2",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.24.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-17T21:52:18+00:00"
+            "time": "2026-08-17T22:56:40+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Picks up [v1.24.0](https://github.com/Joomla-Bible-Study/cwm-build-tools/releases/tag/v1.24.0) and wires `cwm-lint-workflows` into `check`.

## Why here specifically

This repo's `e2e.yml` had **both** faults today:

- **`build/reset-testsite.php`** was still listed after the file was deleted in favour of the shared `cwm-reset-testsite` command — an entry that matched nothing and guarded nothing
- **`composer.lock` was missing**, so a `cwm/build-tools` bump — which replaces the harness's tooling wholesale — merged without the install job running at all

Both were found by eye. Running the lint in `check` means the next one is caught by a command.

## What it reports today

```
.github/workflows/ci.yml:29
    notice: paths-ignore '.claude/**' matches no tracked file — harmless, and expected if the path is gitignored
Checked 2 workflow(s) with path filters against 349 tracked files.
No stale `paths` entry. 1 paths-ignore notice(s) above, which do not fail the run.
```

**Exit 0**, and this notice should stay a notice: `.claude/` exists and is gitignored, so excluding it from triggering CI is deliberate and correct. A tracked-file check cannot tell that from an exclusion whose target was deleted — which is exactly why a stale `paths-ignore` does not fail the run. That distinction came from running the tool against this repo during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
