### PR TITLE
chore(ci): drop the .claude paths-ignore entry, which excludes nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ on:
       - '**.md'
       - 'admin/language/**'
       - 'site/language/**'
-      - '.claude/**'
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
`.claude/` is **gitignored** in this repo, so nothing under it can appear in a commit — and a path that can never be in a diff can never trigger a workflow. The exclusion was **inert**, not wrong.

Removing it is what makes `cwm-lint-workflows` quiet here, which matters more than the entry did: a linter that always prints something trains people to skim past the run that finally has a real finding.

```
Checked 2 workflow(s) with path filters against 349 tracked files.
Every filter entry matches something.
```

## One difference between the repos worth knowing

**Proclaim tracks `.claude`** — plans and skills are committed there, with only `settings.local.json` and `worktrees/` gitignored — so its exclusion matches real files and stays. This repo ignores the directory entirely.

That is a deliberate-looking divergence rather than an accident, so I have not touched it. If this project ever starts tracking `.claude` the same way, the exclusion should come back, and the lint will then confirm it resolves.

`site/language/**` stays and was never flagged: unlike Proclaim, this project does ship site-side language files, so that entry matches real tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
