### PR TITLE
refactor(build): migrate verify-migrations to TestSite, dropping the shell_exec workaround

### DIFF
--- a/build/verify-migrations.php
+++ b/build/verify-migrations.php
@@ -40,6 +40,7 @@
 declare(strict_types=1);
 
 use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\TestSite;
 
 $root = \dirname(__DIR__);
 
@@ -234,55 +235,28 @@ foreach ($installs as $install) {
         continue;
     }
 
-    // Read in a child process: every configuration.php declares a class named
-    // JConfig, so requiring a second one in this process is a fatal redeclare —
-    // which is what a run with two role=test installs used to hit.
-    $config = json_decode((string) shell_exec(sprintf(
-        '%s -r %s %s 2>/dev/null',
-        escapeshellarg(PHP_BINARY),
-        escapeshellarg(
-            'require $argv[1]; $c = new JConfig();'
-            . ' echo json_encode([$c->host, $c->user, $c->password, $c->db, $c->dbprefix]);'
-        ),
-        escapeshellarg($configFile)
-    )), true);
-
-    if (!\is_array($config)) {
-        fwrite(STDERR, "  could not read {$configFile}.\n");
+    // configuration.php is parsed as text rather than required. Every one of
+    // them declares a class named JConfig, and classes are process-global, so
+    // requiring a second install's config used to be a fatal redeclare — which
+    // is why this went through a shell_exec child process to read it.
+    try {
+        $site = TestSite::fromPath($install->path);
+        $db   = $site->db();
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, '  ' . $e->getMessage() . "\n");
         $failures++;
 
         continue;
     }
 
-    [$host, $user, $pass, $name, $prefix] = $config;
-
-    $port = 3306;
-
-    if (str_contains($host, ':')) {
-        [$host, $portStr] = explode(':', $host, 2);
-        $port             = (int) $portStr;
-    }
-
-    $db = @new mysqli($host, $user, $pass, $name, $port);
-
-    if ($db->connect_errno !== 0) {
-        fwrite(STDERR, "  DB connection failed: {$db->connect_error}\n");
-        $failures++;
-
-        continue;
-    }
+    $prefix = $site->prefix();
 
     $fail = static function (string $message) use (&$failures): void {
         echo "  FAIL: {$message}\n";
         $failures++;
     };
 
-    $tableExists = static function (string $table) use ($db, $prefix): bool {
-        $like = $db->real_escape_string($prefix . $table);
-        $res  = $db->query("SHOW TABLES LIKE '{$like}'");
-
-        return $res instanceof mysqli_result && $res->num_rows > 0;
-    };
+    $tableExists = static fn (string $table): bool => $site->hasTable('#__' . $table);
 
     $checks = 0;
 
@@ -305,11 +279,7 @@ foreach ($installs as $install) {
 
         foreach ($columns as $column) {
             $checks++;
-            $res = $db->query(
-                "SHOW COLUMNS FROM `{$prefix}{$table}` LIKE '" . $db->real_escape_string($column) . "'"
-            );
-
-            if (!($res instanceof mysqli_result) || $res->num_rows === 0) {
+            if (!$site->hasColumn('#__' . $table, $column)) {
                 $fail("missing column {$table}.{$column}");
             }
         }
@@ -329,17 +299,22 @@ foreach ($installs as $install) {
             $shape = \is_int($key) ? [] : $value;
 
             $checks++;
-            $res = $db->query(
-                "SHOW INDEX FROM `{$prefix}{$table}` WHERE Key_name = '" . $db->real_escape_string($index) . "'"
-            );
-
-            if (!($res instanceof mysqli_result) || $res->num_rows === 0) {
+            if (!$site->hasIndex('#__' . $table, $index)) {
                 $fail("missing index {$table}.{$index}");
 
                 continue;
             }
 
-            $parts = $res->fetch_all(MYSQLI_ASSOC);
+            // Presence is shared; shape is not. Uniqueness and column order are
+            // read here because no other consumer has asked for them yet, and a
+            // primitive with one caller is a guess about the second.
+            $stmt = $db->prepare(
+                'SELECT non_unique AS Non_unique, column_name AS Column_name, seq_in_index AS Seq_in_index '
+                . 'FROM information_schema.statistics '
+                . 'WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?'
+            );
+            $stmt->execute([$prefix . $table, $index]);
+            $parts = $stmt->fetchAll(PDO::FETCH_ASSOC);
             usort($parts, static fn(array $a, array $b): int => $a['Seq_in_index'] <=> $b['Seq_in_index']);
 
             if (isset($shape['unique'])) {
@@ -376,7 +351,6 @@ foreach ($installs as $install) {
 
     echo "  {$checks} assertion(s) checked\n";
 
-    $db->close();
 }
 
 if ($failures > 0) {

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "ext-zip": "*"
   },
   "require-dev": {
-    "cwm/build-tools": "^1.13",
+    "cwm/build-tools": "^1.25",
     "phpunit/phpunit": "^12.5",
     "friendsofphp/php-cs-fixer": "^3.0",
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "021a0bcc862e908954cf3967fa7c41df",
+    "content-hash": "6d103a0a8c6f24eea80e54ff7eaee666",
     "packages": [],
     "packages-dev": [
         {
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "10669fb366d601e4e6e8d12f8c3f95613ddefe56"
+                "reference": "98d95113a81e90b293406886987be9510413e54b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/10669fb366d601e4e6e8d12f8c3f95613ddefe56",
-                "reference": "10669fb366d601e4e6e8d12f8c3f95613ddefe56",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/98d95113a81e90b293406886987be9510413e54b",
+                "reference": "98d95113a81e90b293406886987be9510413e54b",
                 "shasum": ""
             },
             "require": {
@@ -408,10 +408,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.24.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.25.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-17T22:56:40+00:00"
+            "time": "2026-08-18T13:19:39+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
`build/verify-migrations.php` off hand-rolled `mysqli` and onto `TestSite`
(#102 in cwm-build-tools). **388 → 362 lines.**

## The child process goes away

Reading `configuration.php` meant `require`-ing it; every one declares a class
named `JConfig`; classes are process-global — so a run with two `role=test`
installs fatally redeclared it. This file worked around that by shelling out to
a second PHP process per install:

```php
$config = json_decode((string) shell_exec(sprintf(
    '%s -r %s %s 2>/dev/null', ...
```

Parsing the file as text removes the need for the workaround, the `shell_exec`,
and the `2>/dev/null` that was swallowing whatever went wrong inside it.

Proclaim's copy of this file never had the workaround — it genuinely fatals on
a second test install (exit 255). That's fixed in
Joomla-Bible-Study/Proclaim#1891. The two files disagreeing about something
that wasn't stylistic is how the bug surfaced.

## And a latent false pass

The table check was `SHOW TABLES LIKE '{$prefix}{$table}'`. `LIKE` treats `_`
as a single-character wildcard — every Joomla prefix ends in one, and these
table names carry three more:

```sql
SELECT "j6devXlivingwordXplans" LIKE "j6dev_livingword_plans";  -- 1  (matches!)
SELECT "j6devXlivingwordXplans" =    "j6dev_livingword_plans";  -- 0
```

So an unrelated table could satisfy a "table exists" assertion. `hasTable()`
asks `information_schema` with an equality match. No current table name
collides, which is why this is a latent fix and the output below is unchanged.

## Index shape stays here

Presence moves to `hasIndex()`. **Uniqueness and column order stay local**, now
on PDO instead of `SHOW INDEX` — no other consumer has asked for shape yet, and
a primitive with one caller is a guess about the second. This file's index
checks are richer than Proclaim's and that is worth keeping.

## Verified

Byte-identical output against two live sites, re-checked against the
**published `v1.25.0`** rather than a local working tree:

| site | state | result |
|---|---|---|
| `j6-test` | nothing installed | every table check fails, exit 1 — identical |
| `j6-dev` | fully installed | all **24** assertions pass including index shape — identical |

Requires `cwm/build-tools ^1.25`; constraint and lock bumped here.