### PR TITLE
refactor(build): seed_scenarios reads one source, not two

### DIFF
--- a/build/seed_scenarios.php
+++ b/build/seed_scenarios.php
@@ -26,6 +26,7 @@
  */
 
 use CWM\BuildTools\Dev\InstallConfig;
+use CWM\BuildTools\Dev\TestSite;
 use CWM\BuildTools\Dev\PropertiesReader;
 
 const ROOT = __DIR__ . '/..';
@@ -292,8 +293,15 @@ function main(array $argv): int
 
     try {
         $install = resolveInstall($args['install'] ?? null);
-        $prefix  = readTablePrefix($install);
-        $pdo     = connect($install);
+
+        // The install supplies the path; the credentials and the prefix both
+        // come from the site's own configuration.php. Previously the prefix was
+        // read from there and the credentials from build.properties, so when
+        // the two disagreed this connected to one database and wrote with the
+        // other's prefix.
+        $site   = TestSite::fromInstall($install);
+        $prefix = $site->prefix();
+        $pdo    = $site->db();
     } catch (\RuntimeException $e) {
         fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
 
@@ -301,7 +309,7 @@ function main(array $argv): int
     }
 
     printf("Install: %s (%s)\n", $install->id, $install->path ?: 'no path');
-    printf("Database: %s, prefix %s\n\n", $install->dbName(), $prefix);
+    printf("Database: %s, prefix %s\n\n", $site->database(), $prefix);
 
     if (isset($args['reset'])) {
         resetSeed($pdo, $prefix, $install);
@@ -423,50 +431,6 @@ function resolveInstall(string|bool|null $id): InstallConfig
     throw new \RuntimeException("Pass --install=<id>. Known: {$known}");
 }
 
-/**
- * The table prefix, read from the install's own configuration.php.
- *
- * build.properties carries credentials but not the prefix, and guessing it
- * from the database name is how a seeder writes into the wrong tables.
- */
-function readTablePrefix(InstallConfig $install): string
-{
-    if ($install->path === '') {
-        throw new \RuntimeException("Install '{$install->id}' declares no path, so its prefix cannot be read.");
-    }
-
-    $config = $install->path . '/configuration.php';
-
-    if (!is_file($config)) {
-        throw new \RuntimeException("No configuration.php at {$config} — is the install provisioned?");
-    }
-
-    if (preg_match('/\$dbprefix\s*=\s*[\'"]([^\'"]*)[\'"]/', (string) file_get_contents($config), $m) !== 1) {
-        throw new \RuntimeException("Could not read \$dbprefix from {$config}.");
-    }
-
-    return $m[1];
-}
-
-function connect(InstallConfig $install): \PDO
-{
-    $host = $install->dbHost();
-    $port = '3306';
-
-    if (str_contains($host, ':')) {
-        [$host, $port] = explode(':', $host, 2);
-    }
-
-    $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $host, $port, $install->dbName());
-
-    try {
-        return new \PDO($dsn, $install->dbUser(), $install->dbPass(), [
-            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-        ]);
-    } catch (\PDOException $e) {
-        throw new \RuntimeException("Could not connect to {$install->dbName()}: " . $e->getMessage());
-    }
-}
 
 /**
  * Create the Joomla accounts, then return username => user id.

--- a/build/seed_scenarios.php
+++ b/build/seed_scenarios.php
@@ -26,8 +26,8 @@
  */
 
 use CWM\BuildTools\Dev\InstallConfig;
-use CWM\BuildTools\Dev\TestSite;
 use CWM\BuildTools\Dev\PropertiesReader;
+use CWM\BuildTools\Dev\TestSite;
 
 const ROOT = __DIR__ . '/..';
 


### PR DESCRIPTION
`build/seed_scenarios.php` took its **credentials from `build.properties`** and
its **table prefix from the install's own `configuration.php`**, which it
regex-parsed itself:

```php
function connect(InstallConfig $install): \PDO
{
    $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $host, $port, $install->dbName());
    return new \PDO($dsn, $install->dbUser(), $install->dbPass(), [...]);
}

preg_match('/\$dbprefix\s*=\s*[\'"]([^\'"]*)[\'"]/', file_get_contents($config), $m);
```

When the two disagree, it connects to the database `build.properties` names and
writes with the prefix the site actually uses. That is precisely the failure
`Dev\TestSite` was extracted to remove — its docblock already spells out why
`configuration.php` wins.

`TestSite::fromInstall()` takes the path from the install and everything else
from the site. 987 → 951 lines.

## Verified

Old and new resolve identically across **all five** installs in
`build.properties`, so the line this prints is unchanged:

```
j5         prefix j5_dev_/j5_dev_  db j5_dev/j5_dev    agree
j6         prefix ekp24_/ekp24_    db j6-dev/j6-dev    agree
j6-test    prefix j6test_/j6test_  db j6_test/j6_test  agree
j62        prefix j6sga_/j6sga_    db j62_dev/j62_dev  agree
j70        prefix e91ja_/e91ja_    db j70_dev/j70_dev  agree
```

and `TestSite` connects for each. I verified connection resolution directly
rather than by running the seeder, because every path through it writes — there
is no read-only mode that reaches the database.

## Why now

This is a #102-class file the original twelve-file survey missed: that survey
looked for `mysqli`, and this one was already PDO.

It is also the **last reader** of `db_host` / `db_user` / `db_pass` /
`db_name`, which unblocks Joomla-Bible-Study/cwm-build-tools#131 — an issue
whose claim that nothing read them was wrong, because the search behind it only
covered build-tools. Correction recorded
[on the issue](https://github.com/Joomla-Bible-Study/cwm-build-tools/issues/131#issuecomment-5330005249).

Refs Joomla-Bible-Study/cwm-build-tools#131