### PR TITLE
chore(ci): stop writing database keys nothing reads into build.properties

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -161,10 +161,6 @@ jobs:
           builder.j6dev.role=test
           builder.j6dev.path=${SITE_DIR}
           builder.j6dev.url=${SITE_URL}
-          builder.j6dev.db_host=127.0.0.1
-          builder.j6dev.db_user=root
-          builder.j6dev.db_pass=joomla_ci
-          builder.j6dev.db_name=joomla_ci
           builder.j6dev.username=admin
           builder.j6dev.password=admin1234567
           builder.j6dev.email=admin@example.com


### PR DESCRIPTION
`cwm-setup` no longer prompts for or stores `db_host` / `db_user` / `db_pass` /
`db_name` (Joomla-Bible-Study/cwm-build-tools#131) — every command that touches
a database resolves credentials from the install's own `configuration.php`.
This workflow was still generating them by hand.

Nothing reads them here either: `build/seed_scenarios.php` was the last reader
and moved to `TestSite` in #161.

So this removes a throwaway CI password from a generated file, and four lines
that would mislead whoever edits this block next.