### PR TITLE
ci: run the e2e job on every pull request, not an allow-list

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,28 +31,21 @@ on:
     - cron: '23 4 * * *'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'admin/**'
-      - 'site/**'
-      - 'api/**'
-      - 'plg_webservices_livingword/**'
-      - 'plg_task_livingword/**'
-      - 'mod_livingword/**'
-      - 'tests/e2e/**'
-      - 'build/test-install.sh'
-      - 'build/test-upgrade.sh'
-      - 'build/test-release.sh'
-      - 'build/verify-migrations.php'
-      # The harness resets the site through cwm-reset-testsite and resolves its
-      # upgrade baseline through cwm-baseline, both of which live in
-      # cwm/build-tools. A version bump replaces that code wholesale, so the
-      # lock belongs here or the job never sees the tooling it runs on.
-      # (build/reset-testsite.php was listed until it was deleted in favour of
-      # the shared command; the entry outlived the file.)
-      - 'composer.lock'
-      - 'playwright.config.js'
-      - 'cwm-build.config.json'
-      - '.github/workflows/e2e.yml'
+    # ⚠️ No paths: filter, deliberately.
+    #
+    # This job was gated on an allow-list, which fails closed: anything nobody
+    # thought of skips, and a skipped job is indistinguishable in a checks list
+    # from a passing one. Across this repository and Proclaim that happened
+    # five times -- most of them found by someone noticing an absent job rather
+    # than by anything reporting it. One was here: a cwm/build-tools bump
+    # replaces the harness's tooling wholesale, and composer.lock was not
+    # listed, so the bump merged without this job running on it.
+    #
+    # The nightly schedule above already ran what the filter skipped, so this
+    # does not make the job see more; it moves the failure from a post-merge
+    # nightly to the pull request that caused it.
+    #
+    # Joomla-Bible-Study/cwm-build-tools#129.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The `paths:` allow-list grew by one entry each time it silently failed to run:
`api/**` missed the admin models the API actually executes (Proclaim#1754,
#1755), then `admin/sql/**` (#1879), then `composer.lock`, then **eight**
`build/` scripts the job invokes through `test-install.sh` (#1892).

Five incidents across two repositories. **Four were found by someone noticing an
absent job in a checks list**, not by anything reporting it.

An allow-list fails closed: anything nobody thought of skips, and a skipped job
is indistinguishable from a passing one.

## Measured before changing it

| | |
|---|---|
| runs the filter avoided, last 120 merges | **30** |
| job duration | **~2.5–3.5 min** |
| CI saved | **~90 minutes**, for the whole period |

That is what the five incidents were bought with.

## What this does *not* do

It does not make the job see more. The **nightly `schedule:`** already ran
everything the filter skipped — and **4 of the last 22 scheduled runs failed**,
so it is genuinely catching things.

What changes is *where the failure lands*: on the pull request that caused it,
rather than on the default branch the next morning where it is a bisect.

## What it costs

The 25 entries go, and so do the comments recording cases 1–5. That is
deliberate: those comments existed to make the filter reviewable, and there is
no longer a filter to review. The record lives in
Joomla-Bible-Study/cwm-build-tools#129, and a condensed version stays in the
workflow explaining why there is no filter.

Only `pull_request` carried the filter — no `push` trigger — so this is one
extra run per PR, not per branch push.

`cwm-lint-workflows` still passes; the other filtered workflow here is
untouched.

Refs Joomla-Bible-Study/cwm-build-tools#129