### PR TITLE
chore(deps): bump cwm/build-tools to ^1.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "ext-zip": "*"
   },
   "require-dev": {
-    "cwm/build-tools": "^1.27",
+    "cwm/build-tools": "^1.28",
     "phpunit/phpunit": "^12.5",
     "friendsofphp/php-cs-fixer": "^3.0",
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "459bf37c793f291542e9b893c7eb6571",
+    "content-hash": "fb80fbce8b95a3592fce67dc8da6b8c4",
     "packages": [],
     "packages-dev": [
         {
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "f189882bbf996b2fab24ea36abd47142010086aa"
+                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/f189882bbf996b2fab24ea36abd47142010086aa",
-                "reference": "f189882bbf996b2fab24ea36abd47142010086aa",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/289b22ac9e0c563458c2d76a1e7240c866f7ef80",
+                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80",
                 "shasum": ""
             },
             "require": {
@@ -408,10 +408,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.27.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.28.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-18T18:01:04+00:00"
+            "time": "2026-08-18T21:22:29+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Two additions, both opt-in — nothing here changes until they are called.

| | |
|---|---|
| `cwm-sync-configs --check` | previews managed-config drift and **exits 1**, for CI |
| `--help` on every command | the last eight now answer it too |

⚠️ **Before wiring `--check` into this repository's CI:** it reports drift
today, and clearing that changes committed files. Worth doing as a deliberate
step rather than as a side effect of enabling the check.

## Verified after the bump

All **29** `cwm-*` commands print help and leave the working tree untouched.

That sweep is what dirtied four working trees during the 1.27 bump — running
`--help` across every binary made `cwm-sync-configs` perform a full sync,
rewriting `.gitignore`, `build.dist.properties`, `.editorconfig` and
`phpunit.xml`. Fixed in v1.27.1, and confirmed here against the published
release rather than assumed.