### PR TITLE
ci: authenticate the GitHub API calls the build makes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # ⚠️ build/fetch_dependencies.php asks api.github.com for the latest
+  # CWMScriptureLinks release. Unauthenticated, that shares a rate limit with
+  # every other job on the runner's IP address, and a build fails with HTTP 403
+  # for reasons that have nothing to do with this repository -- which is how it
+  # failed on the v1.28 dependency bump.
+  #
+  # The script already sends `Authorization: Bearer` when GITHUB_TOKEN or
+  # GH_TOKEN is set; it was simply never given one. The automatic token lifts
+  # the limit from 60 requests an hour to 1000.
+  #
+  # Set at workflow level rather than on the one step that builds today: the
+  # fetch runs from the preBuild hook, so any future build step needs it too,
+  # and a step added without it would fail the same way.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   ci:
     name: PHP Lint & Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,20 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # ⚠️ build/fetch_dependencies.php asks api.github.com for the latest
+  # CWMScriptureLinks release. Unauthenticated, that shares a rate limit with
+  # every other job on the runner's IP address, and a build fails with HTTP 403
+  # for reasons that have nothing to do with this repository -- which is how it
+  # failed on the v1.28 dependency bump.
+  #
+  # The script already sends `Authorization: Bearer` when GITHUB_TOKEN or
+  # GH_TOKEN is set; it was simply never given one. The automatic token lifts
+  # the limit from 60 requests an hour to 1000.
+  #
+  # Set at workflow level rather than on the one step that builds today: the
+  # fetch runs from the preBuild hook, so any future build step needs it too,
+  # and a step added without it would fail the same way.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   JOOMLA_VERSION: '5.4.3'
   SITE_DIR: /home/runner/joomla-site
   SITE_URL: http://127.0.0.1:8890


### PR DESCRIPTION
`build/fetch_dependencies.php` asks `api.github.com` for the latest
CWMScriptureLinks release and downloads its assets. **Unauthenticated**, that
shares a 60-per-hour limit with every other job on the runner's IP — so a build
fails for reasons that have nothing to do with this repository:

```
Error: GitHub API returned HTTP 403 for .../releases/latest
API rate limit exceeded for 20.112.122.51
```

That is what failed the v1.28 dependency bump (#166). It passed on re-run, which
is the tell: nothing about the change was wrong, and nothing about the next run
will be either — until the limit is hit again.

## The script was already written for this

`ghToken()` reads `GITHUB_TOKEN`, then `GH_TOKEN`, then the `gh` CLI's stored
credential, and **both** call sites send `Authorization: Bearer` when it finds
one. Its docblock already names the 60-per-hour cap.

I checked both call sites rather than assuming, and confirmed the pickup:

```
GITHUB_TOKEN set  -> picked up
GH_TOKEN set      -> picked up
```

CI simply never gave it a token. The automatic one lifts the limit to 1000/hour.

## Why workflow level

Set in `ci.yml` and `e2e.yml` at workflow level rather than on the one step that
builds today. The fetch runs from the **preBuild hook**, so it fires on any
build — a step added later without the `env` would fail in exactly the same way,
intermittently, and look like flakiness rather than a missing variable.

`release.yml` already passes a token and is unchanged.

## Scope

The other three consumers need nothing — I checked each `preBuild`, and this is
the only build in the family that talks to the GitHub API.