### PR TITLE
chore(deps): bump cwm/build-tools to ^1.29

### DIFF
--- a/build.dist.properties
+++ b/build.dist.properties
@@ -23,16 +23,39 @@
 # version is set).
 joomla.version = 5.4.2
 
-# Comma-separated list of install ids. Each id must have a matching block
-# of `builder.<id>.*` keys below.
-builder.installs = j5, j6, j5-test
+# Comma-separated list of install ids. Each id must have a matching block of
+# `builder.<id>.*` keys below.
+#
+# Two examples ship here — one of each role. **Add as many as you need**: one
+# per Joomla version you support, or several of the same version. To add one,
+# copy a block, change the id, and add that id to this list. Ids are arbitrary
+# labels (`j6`, `j7-test`, `client-staging`) — nothing keys off the name.
+builder.installs = j5, j5-test
 
-# ----- Joomla 5 development install ----------------------------------------
-# role values:
-#   dev  — symlink-style working install. `cwm-link` deploys here.
-#   test — artifact-style install. `cwm-install-zip` deploys the dist zip
-#          here and `cwm-verify --target test` queries it.
+# ----- ROLES ----------------------------------------------------------------
+# Every install declares a role, and the role decides how it is treated. This is
+# the most important line in each block:
+#
+#   role = dev    SYMLINKED. `cwm-link` points the install's extension
+#                 directories at your working repo, so edits appear on the site
+#                 immediately with no build step. Never wiped by any command.
+#
+#   role = test   NOT SYMLINKED — a real, file-backed install. `cwm-install-zip`
+#                 deploys the built dist zip here, and the release harness
+#                 (`composer test:install` / `test:upgrade`) WIPES AND
+#                 REINSTALLS it to verify the artifact from a clean slate.
+#
 # (Default role is `dev` when omitted.)
+#
+# Never point a `role = test` install at a symlinked directory. Those commands
+# delete extension directories, and is_dir() is true for a symlink to a
+# directory — so a linked test install means the delete walks through the link
+# and empties your working repo. `cwm-link` skips `role = test` installs for
+# this reason (v1.6.1), and the reset harness strips any stray link it finds
+# before deleting anything (v1.6.2). Both are backstops, not permission to
+# link one.
+
+# ----- Development install (symlinked) --------------------------------------
 builder.j5.role        = dev
 builder.j5.path        = /path/to/joomla5
 builder.j5.url         = https://j5-dev.local
@@ -41,20 +64,11 @@ builder.j5.admin_user  = admin
 builder.j5.admin_pass  = admin
 builder.j5.admin_email = admin@example.com
 
-# ----- Joomla 6 development install ----------------------------------------
-builder.j6.role        = dev
-builder.j6.path        = /path/to/joomla6
-builder.j6.url         = https://j6-dev.local
-builder.j6.version     = 6.0.0
-builder.j6.admin_user  = admin
-builder.j6.admin_pass  = admin
-builder.j6.admin_email = admin@example.com
-
-# ----- Joomla 5 test install (artifact verification) ----------------------
-# `cwm-install-zip` deploys the built dist zip into this install so you can
-# exercise the install scriptfile, manifest declarations, and schema
-# migrations end-to-end before release. Remove if you don't run a separate
-# test install — or delete j5-test from `builder.installs` above.
+# ----- Test install (real files, wiped by the release harness) --------------
+# Exercises the install scriptfile, manifest declarations and schema migrations
+# end-to-end before release. Remove this block and drop `j5-test` from
+# `builder.installs` if you don't run one — the harness reports having no
+# target rather than failing.
 builder.j5-test.role        = test
 builder.j5-test.path        = /path/to/joomla5-test
 builder.j5-test.url         = https://j5-test.local
@@ -62,21 +76,6 @@ builder.j5-test.version     = 5.4.2
 builder.j5-test.admin_user  = admin
 builder.j5-test.admin_pass  = admin
 builder.j5-test.admin_email = admin@example.com
-
-# ----- Front-end member account (Playwright member-* projects) -------------
-# The member-j6 project drives the site as a subscriber rather than as an
-# admin, so the specs see the permissions a real visitor gets. Global setup
-# seeds this account through the install's own `cli/joomla.php user:add` and
-# subscribes it to a plan, which needs `builder.<id>.path` to be resolvable —
-# either declared per install, or matchable by directory name in
-# `builder.joomla_paths`.
-#
-# All three default, so most developers need none of these. Set them only to
-# use an account you already have.
-#
-# builder.j6dev.member_username = lw-e2e-member
-# builder.j6dev.member_password = lw-e2e-member-pw-9134
-# builder.j6dev.member_email    = lw-e2e-member@example.com
 
 # ----- CWM sibling paths --------------------------------------------------
 # Per-developer absolute paths to CWM siblings declared in

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "ext-zip": "*"
   },
   "require-dev": {
-    "cwm/build-tools": "^1.28",
+    "cwm/build-tools": "^1.29",
     "phpunit/phpunit": "^12.5",
     "friendsofphp/php-cs-fixer": "^3.0",
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb80fbce8b95a3592fce67dc8da6b8c4",
+    "content-hash": "42c92b43c3e249674198cbbfa64395ca",
     "packages": [],
     "packages-dev": [
         {
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80"
+                "reference": "3b99210586ca0e8b68c87ded8028f61fbe824292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/289b22ac9e0c563458c2d76a1e7240c866f7ef80",
-                "reference": "289b22ac9e0c563458c2d76a1e7240c866f7ef80",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/3b99210586ca0e8b68c87ded8028f61fbe824292",
+                "reference": "3b99210586ca0e8b68c87ded8028f61fbe824292",
                 "shasum": ""
             },
             "require": {
@@ -343,7 +343,8 @@
                 "bin/cwm-lint-comments",
                 "bin/cwm-lint-workflows",
                 "bin/cwm-reset-testsite",
-                "bin/cwm-verify-update-stream"
+                "bin/cwm-verify-update-stream",
+                "bin/cwm-schema-replay"
             ],
             "type": "library",
             "autoload": {
@@ -408,10 +409,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.28.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.29.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-18T21:22:29+00:00"
+            "time": "2026-08-19T12:54:25+00:00"
         },
         {
             "name": "ergebnis/agent-detector",

--- a/docker-compose.databases.yml
+++ b/docker-compose.databases.yml
@@ -1,0 +1,70 @@
+# Disposable MySQL and MariaDB for extension development.
+#
+# Databases only. Apache and PHP stay wherever you already have them (MAMP,
+# Herd, Valet, a system install) — this exists so schema work has a database
+# that is *known empty*, not to move your web stack.
+#
+# Why empty matters: a leftover table from the previous attempt turns a real
+# failure into a pass. That is the same defect this toolchain keeps finding
+# elsewhere — a check that reports success while testing something other than
+# what it claims.
+#
+#   docker compose -f docker-compose.databases.yml up -d       # start
+#   docker compose -f docker-compose.databases.yml down -v     # stop and wipe
+#
+# ⚠️ The reset is `down -v`, not `down`. Both images declare a VOLUME for their
+# data directory, so a plain `down` leaves an anonymous volume behind and the
+# next `up` inherits it — a leftover table from the previous attempt, which is
+# the exact failure this file exists to prevent.
+#
+# A tmpfs data directory would make that impossible, and was the first thing
+# tried here. It does not work: MySQL 8 defaults `innodb_flush_method` to
+# `O_DIRECT`, which tmpfs does not support, so the server fails to start.
+# Checked against MySQL 8.0.44 rather than assumed. `down -v` is the reset.
+#
+# Do not point anything you care about at these.
+#
+# Ports are deliberately not 3306: a developer's existing local MySQL keeps
+# running. Set them in .env if these clash.
+#
+#   CWM_MYSQL_PORT=3307   CWM_MARIADB_PORT=3308
+#
+# Point the test suite at one with:
+#
+#   CWM_TEST_MYSQL_DSN='mysql:host=127.0.0.1;port=3307;dbname=cwm_test' \
+#     CWM_TEST_MYSQL_USER=root CWM_TEST_MYSQL_PASSWORD=root composer test
+#
+# MariaDB is here because it is a real second engine our users run, not for
+# completeness. PostgreSQL is deliberately absent — this toolchain declares
+# MySQL/MariaDB only, and shipping a container for an engine we do not support
+# would imply otherwise.
+
+services:
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: cwm_test
+    ports:
+      - "${CWM_MYSQL_PORT:-3307}:3306"
+    healthcheck:
+      # Same probe this project's CI uses for the same image.
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: cwm_test
+    ports:
+      - "${CWM_MARIADB_PORT:-3308}:3306"
+    healthcheck:
+      # MariaDB ships its own probe; mysqladmin ping reports healthy before
+      # InnoDB has finished coming up.
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
Picks up **v1.29.0**, which adds `cwm-schema-replay` — a command that *executes* an extension's migration files against a scratch schema, rather than checking their effects on a site that never ran them.

A fresh install applies `install.sql` and Joomla stamps `#__schemas` at the newest version **without running a single update file**, so every existing check passes while the migration files themselves have only ever been executed by a user's upgrade.

`^1.28` does not resolve 1.29, so the constraint bump is what makes it available at all.

**Not adopted here.** Using it needs a committed baseline and a `schemaReplay` block, which is its own change.

`composer sync-configs` ran alongside, because managed config that has quietly fallen behind is invisible until someone happens to run a sync.
One file had:

**`build.dist.properties`** is fully rewritten from the template, which is how that file works — it is the documented example, not what this repo runs against. The real `build.properties` is gitignored and untouched. The visible change is the example install list returning to the template's two roles.

**`docker-compose.databases.yml`** is created, not updated: a one-time seed for a known-empty MySQL/MariaDB, never touched again.

Worth adopting here in particular: this repo ships **8 migrations that nothing currently executes**.

Suite green: **89 tests, 2077 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
