### PR TITLE
chore(deps): bump cwm/build-tools to ^1.31

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "ext-zip": "*"
   },
   "require-dev": {
-    "cwm/build-tools": "^1.29",
+    "cwm/build-tools": "^1.31",
     "phpunit/phpunit": "^12.5",
     "friendsofphp/php-cs-fixer": "^3.0",
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42c92b43c3e249674198cbbfa64395ca",
+    "content-hash": "59261a9fcc8a8075d3e40138ad8d15d0",
     "packages": [],
     "packages-dev": [
         {
@@ -292,16 +292,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.29.1",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "14f68480c5b98eec5c663735b8ece33b805d4be9"
+                "reference": "f9921bb1a2249524020d044f2a97a211cf273390"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/14f68480c5b98eec5c663735b8ece33b805d4be9",
-                "reference": "14f68480c5b98eec5c663735b8ece33b805d4be9",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/f9921bb1a2249524020d044f2a97a211cf273390",
+                "reference": "f9921bb1a2249524020d044f2a97a211cf273390",
                 "shasum": ""
             },
             "require": {
@@ -409,10 +409,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.29.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.31.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-19T13:25:44+00:00"
+            "time": "2026-08-19T14:13:35+00:00"
         },
         {
             "name": "ergebnis/agent-detector",


### PR DESCRIPTION
Catches up with two releases cut while wiring schema replay through the family.

**1.30.0 is the one that matters here**: it added `run-schema-replay` to the reusable `joomla-package-ci.yml` this project delegates its CI to.

That input was already reaching this repository — the workflow is referenced `@v1`, a moving tag, so the pipeline updated on release regardless of the composer constraint. The bump makes the constraint say so.

1.31.0 added the same input to the *library* workflow, which this project does not use.

`composer sync-configs` alongside; nothing was out of date.

## Verified, not assumed

```
baseline 5.4.0, 3 of 8 migrations to replay
✓ 36 statements applied
```

Identical to 1.29.1.

Suite green: **89 tests, 2077 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6R7PVoGnXK93SRiMUHntV
